### PR TITLE
Add animated visualization of epidemic processes on lattices

### DIFF
--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -165,6 +165,12 @@ export LatticeVisualizer
 export plot_state, plot_comparison, plot_spread_pattern, set_color_scheme!
 export quick_lattice_plot, save_lattice_plot
 
+# Animated visualization
+include("visualization/animation.jl")
+export FrameSampler, EveryStep, EveryNSteps, TimeInterval
+export SimulationRecording, record_simulation, num_frames
+export animate_recording, animate_simulation
+
 # =============================================================================
 # Package Information and Convenience Functions
 # =============================================================================

--- a/src/visualization/animation.jl
+++ b/src/visualization/animation.jl
@@ -1,0 +1,377 @@
+"""
+Animated visualization of epidemic processes on square lattices.
+
+The performance-optimized Gillespie loop (`step!`) is left untouched. Instead, a
+dedicated runner replays it while capturing lightweight `Vector{Int8}` state
+snapshots according to a pluggable *frame sampler*, then renders the snapshots
+into an animated GIF using the existing `LatticeVisualizer` heatmap.
+
+Two sampling regimes (see `FrameSampler`):
+- `TimeInterval(dt)` — equal simulation-time spacing; faithful temporal playback,
+  the right choice for large lattices (Gillespie `dt` varies per step, so
+  equal-time frames preserve the true speed of spread).
+- `EveryStep()`      — one frame per transition; best for small lattices where
+  every single event is interesting.
+
+# Example
+```julia
+using GraphEpimodels
+
+# Small lattice — animate every transition
+sir = create_sir_simulation(30, 30, 0.6, 1.0; initial_infected=:center, rng_seed=1)
+animate_simulation(sir; sampler=EveryStep(), color_scheme=:sir, filename="sir_small.gif")
+
+# Large lattice — equal-time sampling for faithful playback
+big = create_sir_simulation(200, 200, 0.6, 1.0; initial_infected=:center, rng_seed=1)
+animate_simulation(big; sampler=TimeInterval(0.5), max_time=40.0, filename="sir_large.gif")
+```
+"""
+
+using Plots
+
+# =============================================================================
+# Frame Samplers — decide *when* a snapshot is captured
+# =============================================================================
+
+"""
+Abstract base type for frame-sampling policies used during recording.
+
+A sampler answers a single question via `should_capture`: given the current
+simulation time/step and the time/step of the previously captured frame, should
+a new frame be captured now?
+"""
+abstract type FrameSampler end
+
+"""
+Capture one frame per transition (every `step!`).
+
+Best for small lattices, where seeing every individual event is useful. Frame
+count grows with the number of steps, so avoid on large lattices.
+"""
+struct EveryStep <: FrameSampler end
+
+"""
+Capture a frame every `n` steps.
+
+A middle ground between `EveryStep` and `TimeInterval` when you want to thin a
+per-transition animation by a fixed stride.
+"""
+struct EveryNSteps <: FrameSampler
+    n::Int
+
+    function EveryNSteps(n::Int)
+        n >= 1 || throw(ArgumentError("EveryNSteps requires n >= 1, got $n"))
+        new(n)
+    end
+end
+
+"""
+Sample-and-hold on a fixed time grid `0, dt, 2dt, ...`.
+
+Emits exactly one frame per grid point, each showing the state held at that grid
+time, so frames are equally spaced in *simulation time* (not steps). Played back
+at a constant fps this reflects the true speed of the process — and a slow period
+(a single large Gillespie `dt` spanning several grid points) correctly shows as a
+held/paused image rather than being skipped over.
+
+This is the right choice for large lattices: the number of frames is bounded by
+`total_time / dt` regardless of how many Gillespie steps occur, and state
+snapshots are taken only at grid crossings, never on every step.
+"""
+struct TimeInterval <: FrameSampler
+    dt::Float64
+
+    function TimeInterval(dt::Real)
+        dt > 0 || throw(ArgumentError("TimeInterval requires dt > 0, got $dt"))
+        new(Float64(dt))
+    end
+end
+
+# Per-step capture logic, dispatched on sampler type. `push_state!(time, step)`
+# snapshots the current graph state into the recording. Returns the (possibly
+# updated) time-grid cursor `next_grid`, which only `TimeInterval` advances.
+
+# One frame per transition.
+function _capture_after_step!(::EveryStep, push_state!, t::Float64, s::Int, next_grid::Float64)
+    push_state!(t, s)
+    return next_grid
+end
+
+# One frame every `n` steps.
+function _capture_after_step!(samp::EveryNSteps, push_state!, t::Float64, s::Int, next_grid::Float64)
+    if s % samp.n == 0
+        push_state!(t, s)
+    end
+    return next_grid
+end
+
+# Sample-and-hold: emit one frame per grid point reached by this step, each
+# stamped with its grid time. A single large `dt` that spans several grid points
+# therefore produces several (held) frames, giving uniform spacing in simulation
+# time. Snapshots are taken only here, at crossings — not on every step. (The held
+# state is the post-step state, so a frame can be at most one event ahead of the
+# exact held value: a single-node difference, visually negligible.)
+function _capture_after_step!(samp::TimeInterval, push_state!, t::Float64, s::Int, next_grid::Float64)
+    while next_grid <= t
+        push_state!(next_grid, s)
+        next_grid += samp.dt
+    end
+    return next_grid
+end
+
+# =============================================================================
+# Simulation Recording — captured frames + metadata
+# =============================================================================
+
+"""
+A recorded simulation: a sequence of lattice state snapshots with metadata.
+
+Frames are raw `Int8` state vectors (1 byte per node), so memory stays modest;
+time-based sampling keeps the frame count bounded for large lattices.
+
+# Fields
+- `graph::AbstractEpidemicGraph`: The graph (kept for dimensions / rendering)
+- `frames::Vector{Vector{Int8}}`: One node-state snapshot per frame
+- `times::Vector{Float64}`: Simulation time of each frame
+- `steps::Vector{Int}`: Step count at each frame
+- `counts::Vector{NTuple{3, Int}}`: `(S, I, R)` counts per frame (for titles)
+- `process_name::String`: Short process name (e.g. "SIR") for titles
+"""
+struct SimulationRecording
+    graph::AbstractEpidemicGraph
+    frames::Vector{Vector{Int8}}
+    times::Vector{Float64}
+    steps::Vector{Int}
+    counts::Vector{NTuple{3, Int}}
+    process_name::String
+end
+
+"""Number of recorded frames."""
+num_frames(rec::SimulationRecording)::Int = length(rec.frames)
+
+# =============================================================================
+# Internal Helpers
+# =============================================================================
+
+"""Count `(S, I, R)` directly from a raw Int8 snapshot."""
+function _count_states_raw(states::Vector{Int8})::NTuple{3, Int}
+    nS = 0; nI = 0; nR = 0
+    @inbounds for v in states
+        if v == STATE_SUSCEPTIBLE
+            nS += 1
+        elseif v == STATE_INFECTED
+            nI += 1
+        else
+            nR += 1
+        end
+    end
+    return (nS, nI, nR)
+end
+
+"""Short process name for frame titles, e.g. `SIRProcess` -> "SIR"."""
+function _process_name(process::AbstractEpidemicProcess)::String
+    name = string(nameof(typeof(process)))
+    return endswith(name, "Process") ? name[1:end-7] : name
+end
+
+"""Build the per-frame title string from recorded metadata."""
+function _frame_title(rec::SimulationRecording, idx::Int)::String
+    t = rec.times[idx]
+    s = rec.steps[idx]
+    (_, nI, nR) = rec.counts[idx]
+    return "$(rec.process_name)  (t=$(round(t, digits=2)), step=$s, I=$nI, R=$nR)"
+end
+
+# =============================================================================
+# Recorder — replays the Gillespie loop and captures frames
+# =============================================================================
+
+"""
+Run a process while recording state snapshots according to `sampler`.
+
+Mirrors the loop and termination conditions of `run_simulation`, but instead of
+the heavyweight `save_history` it captures lightweight `Int8` snapshots. The
+initial state (t=0) and the final state are always captured, so the animation
+starts and ends on the true endpoints.
+
+Runs from the process's *current* state (like `run_simulation`); pass a freshly
+created `create_*_simulation(...)` process for a clean run.
+
+# Arguments
+- `process::AbstractEpidemicProcess`: The process to run and record
+- `sampler::FrameSampler`: When to capture frames (default: `TimeInterval(1.0)`)
+- `max_time::Float64`: Stop at this simulation time (default: `Inf`)
+- `max_steps::Int`: Stop after this many steps (default: `typemax(Int)`)
+- `stop_on_escape::Bool`: Stop once infection reaches the boundary (default: false)
+
+# Returns
+- `SimulationRecording`
+"""
+function record_simulation(process::AbstractEpidemicProcess;
+                           sampler::FrameSampler = TimeInterval(1.0),
+                           max_time::Float64 = Inf,
+                           max_steps::Int = typemax(Int),
+                           stop_on_escape::Bool = false)::SimulationRecording
+    graph = get_graph(process)
+
+    frames = Vector{Vector{Int8}}()
+    times  = Float64[]
+    steps  = Int[]
+    counts = NTuple{3, Int}[]
+
+    # Snapshot the current graph state, stamped with the given (time, step).
+    push_state! = function (t::Float64, s::Int)
+        snapshot = copy(node_states_raw(graph))
+        push!(frames, snapshot)
+        push!(times, t)
+        push!(steps, s)
+        push!(counts, _count_states_raw(snapshot))
+    end
+
+    # Initial frame (t=0, step 0)
+    push_state!(current_time(process), step_count(process))
+
+    # Time-grid cursor (used only by TimeInterval): first grid point after t=0.
+    next_grid = sampler isa TimeInterval ? sampler.dt : 0.0
+
+    while (current_time(process) < max_time &&
+           step_count(process) < max_steps &&
+           is_active(process))
+
+        dt = step!(process)
+
+        next_grid = _capture_after_step!(sampler, push_state!,
+                                         current_time(process), step_count(process), next_grid)
+
+        # Stop when escaped if requested
+        if stop_on_escape && has_escaped(process)
+            break
+        end
+
+        # No more events possible
+        if dt == Inf
+            break
+        end
+    end
+
+    # Always end on the true final state (avoid duplicating an already-captured frame)
+    if isempty(steps) || steps[end] != step_count(process)
+        push_state!(current_time(process), step_count(process))
+    end
+
+    return SimulationRecording(graph, frames, times, steps, counts, _process_name(process))
+end
+
+# =============================================================================
+# Animation Builder
+# =============================================================================
+
+"""
+Render a recording to an animated GIF using the lattice heatmap.
+
+Each frame is drawn with the same `_render_state_matrix` core used by
+`visualize_state`, so frames look identical to static snapshots.
+
+# Arguments
+- `rec::SimulationRecording`: The recording to animate (must be on a `SquareLattice`)
+- `color_scheme::Symbol`: Color scheme (default: `:sir`)
+- `fps::Int`: Frames per second of the output GIF (default: 15)
+- `filename::String`: Output path (default: "simulation.gif")
+- `figure_size::Tuple{Int, Int}`: Frame size in pixels (default: (600, 600))
+- `show_boundary::Bool`: Highlight the lattice boundary (default: false)
+- `show_grid::Bool`: Show grid lines between nodes (default: false)
+
+# Returns
+- `Plots.AnimatedGif`: The saved animation (also displays inline in notebooks)
+"""
+function animate_recording(rec::SimulationRecording;
+                           color_scheme::Symbol = :sir,
+                           fps::Int = 15,
+                           filename::String = "simulation.gif",
+                           figure_size::Tuple{Int, Int} = (600, 600),
+                           show_boundary::Bool = false,
+                           show_grid::Bool = false)
+    graph = rec.graph
+    graph isa SquareLattice ||
+        throw(ArgumentError("animate_recording currently supports SquareLattice graphs only, " *
+                            "got $(typeof(graph))"))
+
+    viz = LatticeVisualizer(color_scheme = color_scheme,
+                            figure_size = figure_size,
+                            show_boundary = show_boundary,
+                            show_grid = show_grid)
+
+    anim = Animation()
+    for idx in 1:num_frames(rec)
+        p = _render_state_matrix(viz, graph, rec.frames[idx];
+                                 title = _frame_title(rec, idx))
+        frame(anim, p)
+    end
+
+    result = gif(anim, filename; fps = fps)
+    println("Animation saved to: $filename ($(num_frames(rec)) frames, $fps fps)")
+    return result
+end
+
+# =============================================================================
+# Convenience API — run, record, and save in one call
+# =============================================================================
+
+"""
+Run a process and save an animated GIF of its evolution in one call.
+
+Records the run with `record_simulation` and renders it with `animate_recording`.
+
+Returns the `SimulationRecording` so the animation can be re-rendered at a
+different fps / color scheme without re-simulating:
+```julia
+rec = animate_simulation(sir; filename="run.gif")
+animate_recording(rec; fps=30, color_scheme=:medical, filename="run_fast.gif")
+```
+
+Runs from the process's *current* state (like `run_simulation`); pass a freshly
+created `create_*_simulation(...)` process for a clean run.
+
+# Arguments
+- `process::AbstractEpidemicProcess`: The process to run and animate
+- `sampler::FrameSampler`: When to capture frames (default: `TimeInterval(1.0)`)
+- `max_time::Float64`: Stop at this simulation time (default: `Inf`)
+- `max_steps::Int`: Stop after this many steps (default: `typemax(Int)`)
+- `stop_on_escape::Bool`: Stop once infection reaches the boundary (default: false)
+- `color_scheme::Symbol`: Color scheme (default: `:sir`)
+- `fps::Int`: Frames per second of the output GIF (default: 15)
+- `filename::String`: Output path (default: "simulation.gif")
+- `figure_size::Tuple{Int, Int}`: Frame size in pixels (default: (600, 600))
+- `show_boundary::Bool`: Highlight the lattice boundary (default: false)
+- `show_grid::Bool`: Show grid lines between nodes (default: false)
+
+# Returns
+- `SimulationRecording`
+"""
+function animate_simulation(process::AbstractEpidemicProcess;
+                            sampler::FrameSampler = TimeInterval(1.0),
+                            max_time::Float64 = Inf,
+                            max_steps::Int = typemax(Int),
+                            stop_on_escape::Bool = false,
+                            color_scheme::Symbol = :sir,
+                            fps::Int = 15,
+                            filename::String = "simulation.gif",
+                            figure_size::Tuple{Int, Int} = (600, 600),
+                            show_boundary::Bool = false,
+                            show_grid::Bool = false)::SimulationRecording
+    rec = record_simulation(process;
+                            sampler = sampler,
+                            max_time = max_time,
+                            max_steps = max_steps,
+                            stop_on_escape = stop_on_escape)
+
+    animate_recording(rec;
+                      color_scheme = color_scheme,
+                      fps = fps,
+                      filename = filename,
+                      figure_size = figure_size,
+                      show_boundary = show_boundary,
+                      show_grid = show_grid)
+
+    return rec
+end

--- a/src/visualization/lattice_viz.jl
+++ b/src/visualization/lattice_viz.jl
@@ -61,21 +61,45 @@ function visualize_state(viz::LatticeVisualizer, process::AbstractEpidemicProces
                         trim_plot::Bool = false)
     # Validate compatibility
     validate_visualizer_compatibility(viz, process)
-    
+
     graph = get_graph(process)
-    
-    # Extract lattice dimensions and states
-    width, height = graph.width, graph.height
-    states_raw = node_states_raw(graph)
-    
+
+    return _render_state_matrix(viz, graph, node_states_raw(graph);
+                                title = generate_visualization_title(process),
+                                transparent_background = transparent_background,
+                                trim_plot = trim_plot)
+end
+
+"""
+Render a single lattice state (given as a raw Int8 state vector) to a heatmap plot.
+
+This is the shared rendering core used by both `visualize_state` (live process state)
+and the animation builder (recorded frame snapshots), so animation frames are guaranteed
+to look identical to static snapshots.
+
+# Arguments
+- `viz::LatticeVisualizer`: Visualizer holding color scheme / figure settings
+- `lattice::SquareLattice`: The lattice (for dimensions and boundary)
+- `states_raw::Vector{Int8}`: Node states to draw (0=S, 1=I, 2=R)
+- `title::String`: Plot title (default: empty)
+- `transparent_background::Bool`: Draw susceptible nodes transparent (default: false)
+- `trim_plot::Bool`: Remove title/margins/axes for clean output (default: false)
+
+# Returns
+- Plots.jl plot object
+"""
+function _render_state_matrix(viz::LatticeVisualizer, lattice::SquareLattice,
+                              states_raw::Vector{Int8};
+                              title::String = "",
+                              transparent_background::Bool = false,
+                              trim_plot::Bool = false)
+    width, height = lattice.width, lattice.height
+
     # Convert linear state array to 2D matrix for heatmap
     state_matrix = _states_to_matrix(states_raw, height, width)
-    
+
     # Get colors from scheme
     colors = COLOR_SCHEMES[viz.color_scheme]
-    
-    # Create the plot
-    plot_title = generate_visualization_title(process)
 
     # Convert to Float64 for heatmap
     numeric_matrix = Float64.(state_matrix)
@@ -84,9 +108,9 @@ function visualize_state(viz::LatticeVisualizer, process::AbstractEpidemicProces
     else
         color_list = [colors[:susceptible], colors[:infected], colors[:removed]]
     end
-    
+
     p = heatmap(numeric_matrix,
-               title = plot_title,
+               title = title,
                size = viz.figure_size,
                aspect_ratio = :equal,
                showaxis = false,
@@ -96,15 +120,15 @@ function visualize_state(viz::LatticeVisualizer, process::AbstractEpidemicProces
                clims = (0, 2),
                xlims = (0.5, width + 0.5),
                ylims = (0.5, height + 0.5))
-    
+
     # Add boundary highlighting if requested
-    if viz.show_boundary && has_boundary(graph)
-        _add_boundary_overlay!(p, graph, viz)
+    if viz.show_boundary && has_boundary(lattice)
+        _add_boundary_overlay!(p, lattice, viz)
     end
 
     # Remove title and minimize margins if trimming
     if trim_plot
-        plot!(p, 
+        plot!(p,
             title = "",              # Remove title
             margin = 0Plots.mm,      # Remove all margins
             left_margin = 0Plots.mm,  # Explicitly remove left margin
@@ -117,7 +141,7 @@ function visualize_state(viz::LatticeVisualizer, process::AbstractEpidemicProces
             axis = nothing,          # Remove axis completely
             ticks = nothing)         # Remove ticks
     end
-    
+
     return p
 end
 


### PR DESCRIPTION
## Summary

Adds **animation of epidemic process evolution** on square lattices. Until now the package could only render snapshots of a single (usually final) state; this lets you watch a process unfold over time. The performance-optimized Gillespie loop (`step!`) is left completely untouched — a dedicated runner replays the simulation and captures lightweight `Int8` state snapshots.

## How it works

Three layers:

1. **Recording (graph-agnostic)** — `record_simulation` mirrors `run_simulation`'s termination logic and snapshots state into a `SimulationRecording` (raw `Int8` frames + times/steps/counts).
2. **Frame samplers** decide *when* to snapshot:
   - `EveryStep()` — one frame per transition, for **small lattices** (animate every event).
   - `TimeInterval(dt)` — **sample-and-hold** on a fixed simulation-time grid, for **large lattices**. Frames are equally spaced in simulation time, so constant-fps playback reflects the true speed of spread, and slow periods (large Gillespie `dt`) show as held frames instead of being skipped. Snapshots are taken only at grid crossings — not on every step — so it scales to large lattices.
   - `EveryNSteps(n)` — fixed-stride middle ground.
3. **Rendering** — the heatmap core of `visualize_state` is extracted into `_render_state_matrix`, so animation frames render through the exact same code as static snapshots. `animate_recording` builds a `Plots.Animation` and writes a GIF; `animate_simulation(process; ...)` runs + records + saves in one call and returns the recording for re-rendering.

GIF output works on the existing GR backend — no new dependencies.

## API

```julia
# Small lattice — every transition
sir = create_sir_simulation(40, 40, 2.0, 1.0; initial_infected=:center, rng_seed=7)
animate_simulation(sir; sampler=EveryStep(), color_scheme=:sir, filename="sir_small.gif")

# Large lattice — faithful equal-time playback
big = create_sir_simulation(200, 200, 2.0, 1.0; initial_infected=:center, rng_seed=7)
animate_simulation(big; sampler=TimeInterval(0.5), max_time=40.0, filename="sir_large.gif")
```

Works for any model (SIR, ZIM, Maki-Thompson, Chase-escape) on a `SquareLattice` — pick the matching `color_scheme`.

## Changes
- **New** `src/visualization/animation.jl` — samplers, `SimulationRecording`, `record_simulation`, `animate_recording`, `animate_simulation`.
- **Edit** `src/visualization/lattice_viz.jl` — extract `_render_state_matrix`; `visualize_state` becomes a thin wrapper (behavior-preserving).
- **Edit** `src/GraphEpimodels.jl` — include + exports.

## Verification
- `EveryStep` on a spreading 40×40 SIR: 3119 steps → 3120 frames, full lattice coverage.
- `TimeInterval(0.25)`: exactly 64 grid-spaced frames (uniform `dt` spacing) vs 3119 steps.
- Final recorded frame matches `run_simulation`'s end state for both samplers (confirms the rendering refactor is behavior-preserving).
- Existing test suite: **52/52 pass**.

## Notes / future work
- General (`AdjacencyGraph`) animation isn't included — no node-link renderer exists yet — but the recording layer is already graph-agnostic, so adding one later needs no changes here.
- `TimeInterval` frames show the post-step state, so a held frame can be at most one event "early" (a single-node difference, visually negligible; documented in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
