### PR TITLE
Eliminate per-step allocations, fix threaded reproducibility, type-stabilize hot path

### DIFF
--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -58,7 +58,7 @@ export BoundaryCondition, ABSORBING, PERIODIC
 export state_to_int, int_to_state
 
 # Core graph interface functions
-export num_nodes, get_neighbors, node_states_raw, set_node_states_raw!
+export num_nodes, get_neighbors, get_neighbors!, node_states_raw, set_node_states_raw!
 export node_states, set_node_states!
 export get_node_state, set_node_state!
 export get_node_degree, get_boundary_nodes, has_boundary

--- a/src/analysis/survival_analysis.jl
+++ b/src/analysis/survival_analysis.jl
@@ -138,13 +138,17 @@ function _estimate_survival_threaded(
     start_seed::Int
 )::Dict{Symbol, Any}
 
-    # Pre-create one process per thread (eliminates all locking and false sharing)
+    # Pre-create one process per thread (eliminates all locking and false sharing).
+    # NOTE: the loops below MUST use `:static` scheduling. Indexing the pool by
+    # threadid() is only safe when iterations are statically pinned to threads;
+    # under the default `:dynamic` schedule threadid() is not stable across yield
+    # points, so a migrated task could alias another's process and corrupt results.
     thread_processes = [process_factory() for _ in 1:Threads.nthreads()]
-    
+
     if mode == MINIMAL
         survival_count = Threads.Atomic{Int}(0)
-        
-        @showprogress Threads.@threads for i in 1:num_simulations
+
+        @showprogress Threads.@threads :static for i in 1:num_simulations
             # Get this thread's dedicated process (no locking needed)
             thread_process = thread_processes[Threads.threadid()]
             
@@ -178,8 +182,8 @@ function _estimate_survival_threaded(
         # Pre-allocate results arrays
         results = Vector{NamedTuple{(:survived, :time, :size), Tuple{Bool, Float64, Int}}}(undef, num_simulations)
         
-        @showprogress Threads.@threads for i in 1:num_simulations
-            # Get this thread's dedicated process
+        @showprogress Threads.@threads :static for i in 1:num_simulations
+            # Get this thread's dedicated process (see :static note above)
             thread_process = thread_processes[Threads.threadid()]
             
             # Calculate seed for this specific simulation

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -52,9 +52,13 @@ Create a reproducible random number generator.
 - `seed::Union{Int, Nothing}`: Random seed (nothing for non-reproducible)
 
 # Returns
-- `AbstractRNG`: Random number generator
+- `Random.Xoshiro`: Concrete high-performance RNG
+
+The concrete return type matters: an `::AbstractRNG` annotation here would make
+the inferred return abstract, which propagates into the process constructors and
+reintroduces the per-step rand() boxing the RNG type parameter is meant to avoid.
 """
-function create_rng(seed::Union{Int, Nothing} = nothing)::AbstractRNG
+function create_rng(seed::Union{Int, Nothing} = nothing)
     if seed === nothing
         return Random.Xoshiro()
     else

--- a/src/graphs/adjacency.jl
+++ b/src/graphs/adjacency.jl
@@ -86,6 +86,13 @@ function get_neighbors(graph::AdjacencyGraph, node_id::Int)::Vector{Int}
     return graph.adjacency_list[node_id]
 end
 
+# The adjacency list is already stored, so get_neighbors returns it without
+# allocating. The buffer-filling variant therefore just hands back the stored
+# (read-only) vector and ignores the scratch buffer.
+function get_neighbors!(::Vector{Int}, graph::AdjacencyGraph, node_id::Int)::Vector{Int}
+    return get_neighbors(graph, node_id)
+end
+
 @inline function get_node_degree(graph::AdjacencyGraph, node_id::Int)::Int
     if node_id < 1 || node_id > graph.n_nodes
         throw(BoundsError("Node ID $node_id out of range [1, $(graph.n_nodes)]"))

--- a/src/graphs/graphs.jl
+++ b/src/graphs/graphs.jl
@@ -105,6 +105,34 @@ function get_neighbors(graph::AbstractEpidemicGraph, node_id::Int)::Vector{Int}
 end
 
 """
+Non-allocating variant of [`get_neighbors`](@ref).
+
+Returns the neighbors of `node_id` as a vector that callers must treat as
+**read-only**. Concrete graph types may either fill and return the supplied
+`buffer` (so repeated calls reuse one allocation) or return an internally stored
+neighbor vector directly. Either way the returned vector must not be mutated by
+the caller.
+
+This exists so performance-critical event loops (e.g. the ZIM step) can walk a
+node's neighbors without allocating a fresh `Vector{Int}` on every step — a major
+source of multithreaded GC pressure (issues #1 / #3).
+
+The default implementation falls back to the allocating [`get_neighbors`](@ref),
+so it is always correct; graph types override it where a cheaper path exists.
+
+# Arguments
+- `buffer::Vector{Int}`: Caller-owned scratch buffer that may be reused
+- `graph::AbstractEpidemicGraph`: The graph
+- `node_id::Int`: Node identifier (1-indexed)
+
+# Returns
+- `Vector{Int}`: Read-only neighbor list (possibly `buffer`, possibly internal)
+"""
+function get_neighbors!(buffer::Vector{Int}, graph::AbstractEpidemicGraph, node_id::Int)::Vector{Int}
+    return get_neighbors(graph, node_id)
+end
+
+"""
 Get the raw node states as primitive Int8 array (internal, performance-critical).
 
 This is the internal representation used for all performance-critical operations.

--- a/src/graphs/hexagonal_lattice.jl
+++ b/src/graphs/hexagonal_lattice.jl
@@ -99,12 +99,16 @@ function set_node_states_raw!(lattice::HexagonalLattice, states::Vector{Int8})
 end
 
 function get_neighbors(lattice::HexagonalLattice, node_id::Int)::Vector{Int}
+    return get_neighbors!(Int[], lattice, node_id)
+end
+
+function get_neighbors!(neighbors::Vector{Int}, lattice::HexagonalLattice, node_id::Int)::Vector{Int}
     if node_id < 1 || node_id > num_nodes(lattice)
         throw(BoundsError("Node ID $node_id out of range [1, $(num_nodes(lattice))]"))
     end
 
     row, col = _hex_index_to_coord(node_id, lattice.width)
-    neighbors = Int[]
+    empty!(neighbors)
 
     # Two horizontal neighbors (same row).
     _add_hex_neighbor!(neighbors, row, col - 1, lattice)

--- a/src/graphs/lattice.jl
+++ b/src/graphs/lattice.jl
@@ -84,13 +84,17 @@ function set_node_states_raw!(lattice::SquareLattice, states::Vector{Int8})
 end
 
 function get_neighbors(lattice::SquareLattice, node_id::Int)::Vector{Int}
+    return get_neighbors!(Int[], lattice, node_id)
+end
+
+function get_neighbors!(neighbors::Vector{Int}, lattice::SquareLattice, node_id::Int)::Vector{Int}
     if node_id < 1 || node_id > num_nodes(lattice)
         throw(BoundsError("Node ID $node_id out of range [1, $(num_nodes(lattice))]"))
     end
-    
+
     row, col = _index_to_coord(node_id, lattice.height)
-    neighbors = Int[]
-    
+    empty!(neighbors)
+
     if lattice.boundary == ABSORBING
         # Absorbing: only add neighbors within bounds
         _add_neighbor_if_valid!(neighbors, row-1, col, lattice)    # North

--- a/src/graphs/triangular_lattice.jl
+++ b/src/graphs/triangular_lattice.jl
@@ -97,12 +97,16 @@ function set_node_states_raw!(lattice::TriangularLattice, states::Vector{Int8})
 end
 
 function get_neighbors(lattice::TriangularLattice, node_id::Int)::Vector{Int}
+    return get_neighbors!(Int[], lattice, node_id)
+end
+
+function get_neighbors!(neighbors::Vector{Int}, lattice::TriangularLattice, node_id::Int)::Vector{Int}
     if node_id < 1 || node_id > num_nodes(lattice)
         throw(BoundsError("Node ID $node_id out of range [1, $(num_nodes(lattice))]"))
     end
 
     row, col = _tri_index_to_coord(node_id, lattice.width)
-    neighbors = Int[]
+    empty!(neighbors)
 
     # Two horizontal neighbors (same row).
     _add_perimeter_neighbor!(neighbors, row, col - 1, lattice)

--- a/src/models/chasescape.jl
+++ b/src/models/chasescape.jl
@@ -58,8 +58,10 @@ to the approach in ZIM, SIR and Maki-Thompson.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct ChaseEscapeProcess{R<:AbstractRNG} <: SIRLikeProcess
-    graph::AbstractEpidemicGraph
+mutable struct ChaseEscapeProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: SIRLikeProcess
+    # Concrete `graph`/`rng` type parameters keep the neighbor queries and
+    # rand()/randexp() calls in step! statically dispatched and box-free (#1/#3).
+    graph::G
     λ::Float64
     μ::Float64
     ghost::Bool
@@ -67,15 +69,13 @@ mutable struct ChaseEscapeProcess{R<:AbstractRNG} <: SIRLikeProcess
     catch_tracker::DictActiveTracker
     time::Float64
     steps::Int
-    # Parametric on the concrete RNG type to keep rand()/randexp() statically
-    # dispatched and allocation-free in the hot path (see issues #1/#3).
     rng::R
 
-    function ChaseEscapeProcess(graph::AbstractEpidemicGraph, λ::Float64, μ::Float64;
+    function ChaseEscapeProcess(graph::G, λ::Float64, μ::Float64;
                                 ghost::Bool = true,
-                                rng::R = Random.default_rng()) where {R<:AbstractRNG}
+                                rng::R = Random.default_rng()) where {G<:AbstractEpidemicGraph, R<:AbstractRNG}
         _validate_chase_escape_parameters(λ, μ)
-        new{R}(graph, λ, μ, ghost,
+        new{G,R}(graph, λ, μ, ghost,
             DictActiveTracker(), DictActiveTracker(),
             0.0, 0, rng)
     end

--- a/src/models/chasescape.jl
+++ b/src/models/chasescape.jl
@@ -58,7 +58,7 @@ to the approach in ZIM, SIR and Maki-Thompson.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct ChaseEscapeProcess <: SIRLikeProcess
+mutable struct ChaseEscapeProcess{R<:AbstractRNG} <: SIRLikeProcess
     graph::AbstractEpidemicGraph
     λ::Float64
     μ::Float64
@@ -67,13 +67,15 @@ mutable struct ChaseEscapeProcess <: SIRLikeProcess
     catch_tracker::DictActiveTracker
     time::Float64
     steps::Int
-    rng::AbstractRNG
+    # Parametric on the concrete RNG type to keep rand()/randexp() statically
+    # dispatched and allocation-free in the hot path (see issues #1/#3).
+    rng::R
 
     function ChaseEscapeProcess(graph::AbstractEpidemicGraph, λ::Float64, μ::Float64;
                                 ghost::Bool = true,
-                                rng::AbstractRNG = Random.default_rng())
+                                rng::R = Random.default_rng()) where {R<:AbstractRNG}
         _validate_chase_escape_parameters(λ, μ)
-        new(graph, λ, μ, ghost,
+        new{R}(graph, λ, μ, ghost,
             DictActiveTracker(), DictActiveTracker(),
             0.0, 0, rng)
     end
@@ -358,7 +360,7 @@ function create_chase_escape_simulation(graph::AbstractEpidemicGraph,
                                         ghost::Bool = true,
                                         initial_red::Union{Symbol, Vector{Int}} = :center,
                                         initial_blue::Vector{Int} = Int[],
-                                        rng_seed::Union{Int, Nothing} = nothing)::ChaseEscapeProcess
+                                        rng_seed::Union{Int, Nothing} = nothing)
     rng     = create_rng(rng_seed)
     process = ChaseEscapeProcess(graph, λ, μ; ghost = ghost, rng = rng)
 
@@ -387,7 +389,7 @@ function create_chase_escape_simulation(width::Int, height::Int,
                                         boundary::Symbol = :absorbing,
                                         initial_red::Union{Symbol, Vector{Int}} = :center,
                                         initial_blue::Vector{Int} = Int[],
-                                        rng_seed::Union{Int, Nothing} = nothing)::ChaseEscapeProcess
+                                        rng_seed::Union{Int, Nothing} = nothing)
     lattice = create_square_lattice(width, height, boundary)
     return create_chase_escape_simulation(lattice, λ, μ;
                                           ghost        = ghost,

--- a/src/models/epiprocess.jl
+++ b/src/models/epiprocess.jl
@@ -331,8 +331,15 @@ This is the pattern from your efficient old implementation.
 """
 mutable struct DictActiveTracker <: ActiveNodeTracker
     active_nodes::Dict{Int, Int}  # node_id → susceptible_neighbor_count
-    
-    DictActiveTracker() = new(Dict{Int, Int}())
+
+    # Scratch buffers reused by _weighted_sample_active_fast so that weighted
+    # sampling allocates nothing on the hot path. A tracker is owned by a single
+    # process (and thus a single thread during threaded runs), so reusing these
+    # across calls is safe without any locking. See issues #1 / #3.
+    nodes_buf::Vector{Int}        # idx → node_id
+    cumw_buf::Vector{Int}         # idx → cumulative weight up to and including idx
+
+    DictActiveTracker() = new(Dict{Int, Int}(), Int[], Int[])
 end
 
 """
@@ -456,48 +463,45 @@ Uses the standard weighted sampling algorithm:
 - `ArgumentError`: If no active nodes available
 """
 function _weighted_sample_active(tracker::DictActiveTracker, rng::AbstractRNG)::Int
-    if isempty(tracker.active_nodes)
+    n_active = length(tracker.active_nodes)
+    if n_active == 0
         throw(ArgumentError("No active nodes to sample from"))
     end
-    
-    # Special case: single active node
-    if length(tracker.active_nodes) == 1
-        return first(keys(tracker.active_nodes))
-    end
-    
-    # Get total weight (sum of all susceptible neighbor counts)
-    total_weight = get_total_boundary(tracker)
-    
-    if total_weight <= 0
-        throw(ArgumentError("Total weight is zero - no valid nodes to sample"))
-    end
-    
-    # Sample a random value in [0, total_weight)
-    random_value = rand(rng) * total_weight
-    
-    # Find which node this corresponds to using cumulative weights
-    cumulative_weight = 0.0
-    for (node_id, weight) in tracker.active_nodes
-        cumulative_weight += weight
-        if random_value < cumulative_weight
-            return node_id
-        end
-    end
-    
-    # Shouldn't reach here, but return last node as fallback
-    # (can happen due to floating point rounding)
-    return last(keys(tracker.active_nodes))
+
+    # Delegate to the single canonical (deterministic) sampler so that every
+    # active-set size goes through the same order-independent selection. The
+    # previous implementation walked the Dict directly, which made the chosen
+    # node depend on Dict iteration order — see _weighted_sample_active_fast.
+    return _weighted_sample_active_fast(tracker, n_active, rng)
 end
 
 """
-Alternative weighted sampling implementation using pre-allocated arrays.
+Canonical weighted sampler over the active set, using the tracker's buffers.
 
-More efficient for very large numbers of active nodes, but requires allocation.
-Use this version if you have thousands of active nodes.
+Builds a cumulative-weight array and binary-searches it (`O(n)` to fill plus
+`O(log n)` to sample). Two properties matter:
+
+1. **Allocation-free.** The node/cumulative-weight scratch arrays live on the
+   tracker and are resized in place, so this allocates nothing on the hot path.
+   It runs on every Gillespie step of every simulation; per-step heap allocation
+   here previously caused severe multithreaded GC pressure that serialized worker
+   threads (issues #1 and #3).
+
+2. **Deterministic.** Nodes are sampled in a canonical order (ascending node id),
+   NOT in `Dict` iteration order. A `Dict`'s iteration order depends on its
+   insertion/deletion/rehash history, so two trackers with identical contents but
+   different histories — a freshly constructed process vs. one reused across many
+   simulations, or per-thread processes that each ran a different block of work —
+   would otherwise map the same random draw onto different nodes. That made
+   results depend on execution mode (serial vs. threaded) for a fixed seed.
+   Sorting by node id removes the dependence; QuickSort is in-place so this stays
+   allocation-free.
+
+The tracker is owned by a single process, so buffer reuse needs no locking.
 
 # Arguments
 - `tracker::DictActiveTracker`: Active node tracker with neighbor counts
-- `n_active::Int`: Number of active nodes to use for pre-allocation 
+- `n_active::Int`: Number of active nodes (length of `tracker.active_nodes`)
 - `rng::AbstractRNG`: Random number generator
 
 # Returns
@@ -507,40 +511,48 @@ function _weighted_sample_active_fast(tracker::DictActiveTracker, n_active::Int,
     if n_active == 0
         throw(ArgumentError("No active nodes to sample from"))
     end
-    
+
     if n_active == 1
         return first(keys(tracker.active_nodes))
     end
-    
-    # Pre-allocate arrays for better performance with many nodes
-    nodes = Vector{Int}(undef, n_active)
-    weights = Vector{Int}(undef, n_active)
-    
-    # Fill arrays
+
+    # Reuse the tracker's scratch buffers instead of allocating fresh vectors.
+    nodes = tracker.nodes_buf
+    cumw = tracker.cumw_buf
+    resize!(nodes, n_active)
+    resize!(cumw, n_active)
+
+    # Collect node ids, then sort into a canonical order so sampling does not
+    # depend on Dict iteration order (see the docstring). QuickSort is in-place.
     i = 1
-    for (node_id, weight) in tracker.active_nodes
+    for node_id in keys(tracker.active_nodes)
         nodes[i] = node_id
-        weights[i] = weight
         i += 1
     end
-    
-    # Calculate cumulative weights
-    cumsum_weights = cumsum(weights)
-    total_weight = cumsum_weights[end]
-    
+    sort!(nodes; alg = QuickSort)
+
+    # Build cumulative weights in canonical order.
+    running = 0
+    @inbounds for j in 1:n_active
+        running += tracker.active_nodes[nodes[j]]
+        cumw[j] = running
+    end
+
+    total_weight = running
     if total_weight <= 0
         throw(ArgumentError("Total weight is zero - no valid nodes to sample"))
     end
-    
-    # Binary search for efficiency
+
+    # Binary search for efficiency (one rand() call, searchsortedfirst over the
+    # cumulative weights).
     random_value = rand(rng) * total_weight
-    idx = searchsortedfirst(cumsum_weights, random_value)
-    
+    idx = searchsortedfirst(cumw, random_value)
+
     # Handle edge case where random_value == total_weight
     if idx > n_active
         idx = n_active
     end
-    
+
     return nodes[idx]
 end
 

--- a/src/models/maki_thompson.jl
+++ b/src/models/maki_thompson.jl
@@ -50,7 +50,7 @@ identical to the approach in ZIM and SIR.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct MakiThompsonProcess <: SIRLikeProcess
+mutable struct MakiThompsonProcess{R<:AbstractRNG} <: SIRLikeProcess
     graph::AbstractEpidemicGraph
     α::Float64
     β::Float64
@@ -60,14 +60,16 @@ mutable struct MakiThompsonProcess <: SIRLikeProcess
     spreaders::Set{Int}
     time::Float64
     steps::Int
-    rng::AbstractRNG
+    # Parametric on the concrete RNG type to keep rand()/randexp() statically
+    # dispatched and allocation-free in the hot path (see issues #1/#3).
+    rng::R
 
     function MakiThompsonProcess(graph::AbstractEpidemicGraph,
                                   α::Float64, β::Float64,
                                   stifler_contact::Bool;
-                                  rng::AbstractRNG = Random.default_rng())
+                                  rng::R = Random.default_rng()) where {R<:AbstractRNG}
         _validate_mt_parameters(α, β)
-        new(graph, α, β, stifler_contact,
+        new{R}(graph, α, β, stifler_contact,
             DictActiveTracker(), DictActiveTracker(),
             Set{Int}(), 0.0, 0, rng)
     end
@@ -342,7 +344,7 @@ function create_maki_thompson_simulation(graph::AbstractEpidemicGraph,
                                           α::Float64, β::Float64 = 1.0;
                                           stifler_contact::Bool = true,
                                           initial_infected::Union{Symbol, Vector{Int}} = :center,
-                                          rng_seed::Union{Int, Nothing} = nothing)::MakiThompsonProcess
+                                          rng_seed::Union{Int, Nothing} = nothing)
     rng     = create_rng(rng_seed)
     process = MakiThompsonProcess(graph, α, β, stifler_contact; rng = rng)
 
@@ -370,7 +372,7 @@ function create_maki_thompson_simulation(width::Int, height::Int,
                                           stifler_contact::Bool = true,
                                           boundary::Symbol = :absorbing,
                                           initial_infected::Union{Symbol, Vector{Int}} = :center,
-                                          rng_seed::Union{Int, Nothing} = nothing)::MakiThompsonProcess
+                                          rng_seed::Union{Int, Nothing} = nothing)
     lattice = create_square_lattice(width, height, boundary)
     return create_maki_thompson_simulation(lattice, α, β;
                                            stifler_contact   = stifler_contact,

--- a/src/models/maki_thompson.jl
+++ b/src/models/maki_thompson.jl
@@ -50,8 +50,10 @@ identical to the approach in ZIM and SIR.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct MakiThompsonProcess{R<:AbstractRNG} <: SIRLikeProcess
-    graph::AbstractEpidemicGraph
+mutable struct MakiThompsonProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: SIRLikeProcess
+    # Concrete `graph`/`rng` type parameters keep the neighbor queries and
+    # rand()/randexp() calls in step! statically dispatched and box-free (#1/#3).
+    graph::G
     α::Float64
     β::Float64
     stifler_contact::Bool
@@ -60,16 +62,14 @@ mutable struct MakiThompsonProcess{R<:AbstractRNG} <: SIRLikeProcess
     spreaders::Set{Int}
     time::Float64
     steps::Int
-    # Parametric on the concrete RNG type to keep rand()/randexp() statically
-    # dispatched and allocation-free in the hot path (see issues #1/#3).
     rng::R
 
-    function MakiThompsonProcess(graph::AbstractEpidemicGraph,
+    function MakiThompsonProcess(graph::G,
                                   α::Float64, β::Float64,
                                   stifler_contact::Bool;
-                                  rng::R = Random.default_rng()) where {R<:AbstractRNG}
+                                  rng::R = Random.default_rng()) where {G<:AbstractEpidemicGraph, R<:AbstractRNG}
         _validate_mt_parameters(α, β)
-        new{R}(graph, α, β, stifler_contact,
+        new{G,R}(graph, α, β, stifler_contact,
             DictActiveTracker(), DictActiveTracker(),
             Set{Int}(), 0.0, 0, rng)
     end

--- a/src/models/sir.jl
+++ b/src/models/sir.jl
@@ -36,7 +36,7 @@ infected nodes for O(1)-per-step recovery sampling.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct SIRProcess <: SIRLikeProcess
+mutable struct SIRProcess{R<:AbstractRNG} <: SIRLikeProcess
     graph::AbstractEpidemicGraph
     β::Float64
     γ::Float64
@@ -44,12 +44,15 @@ mutable struct SIRProcess <: SIRLikeProcess
     infected_nodes::Set{Int}
     time::Float64
     steps::Int
-    rng::AbstractRNG
+    # Parametric on the concrete RNG type: an abstract `rng::AbstractRNG` field
+    # would make every rand()/randexp() in step! a dynamic dispatch that boxes
+    # its result (~16 bytes/call), adding per-step GC pressure (cf. issues #1/#3).
+    rng::R
 
     function SIRProcess(graph::AbstractEpidemicGraph, β::Float64, γ::Float64;
-                        rng::AbstractRNG = Random.default_rng())
+                        rng::R = Random.default_rng()) where {R<:AbstractRNG}
         _validate_sir_parameters(β, γ)
-        new(graph, β, γ, DictActiveTracker(), Set{Int}(), 0.0, 0, rng)
+        new{R}(graph, β, γ, DictActiveTracker(), Set{Int}(), 0.0, 0, rng)
     end
 end
 
@@ -291,7 +294,7 @@ julia> results = run_simulation(sir; max_time=100.0)
 """
 function create_sir_simulation(graph::AbstractEpidemicGraph, β::Float64, γ::Float64 = 1.0;
                                initial_infected::Union{Symbol, Vector{Int}} = :center,
-                               rng_seed::Union{Int, Nothing} = nothing)::SIRProcess
+                               rng_seed::Union{Int, Nothing} = nothing)
     rng = create_rng(rng_seed)
     process = SIRProcess(graph, β, γ; rng=rng)
 
@@ -317,7 +320,7 @@ Convenience function for creating SIR on square lattices.
 function create_sir_simulation(width::Int, height::Int, β::Float64, γ::Float64 = 1.0;
                                boundary::Symbol = :absorbing,
                                initial_infected::Union{Symbol, Vector{Int}} = :center,
-                               rng_seed::Union{Int, Nothing} = nothing)::SIRProcess
+                               rng_seed::Union{Int, Nothing} = nothing)
     lattice = create_square_lattice(width, height, boundary)
     return create_sir_simulation(lattice, β, γ; initial_infected=initial_infected, rng_seed=rng_seed)
 end

--- a/src/models/sir.jl
+++ b/src/models/sir.jl
@@ -36,23 +36,23 @@ infected nodes for O(1)-per-step recovery sampling.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct SIRProcess{R<:AbstractRNG} <: SIRLikeProcess
-    graph::AbstractEpidemicGraph
+mutable struct SIRProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: SIRLikeProcess
+    # Concrete `graph`/`rng` type parameters: abstract fields would force the
+    # neighbor queries and rand() calls in step! through dynamic dispatch (and
+    # rand() would box its result ~16 bytes/call) — overhead/GC pressure (#1/#3).
+    graph::G
     β::Float64
     γ::Float64
     active_tracker::DictActiveTracker
     infected_nodes::Set{Int}
     time::Float64
     steps::Int
-    # Parametric on the concrete RNG type: an abstract `rng::AbstractRNG` field
-    # would make every rand()/randexp() in step! a dynamic dispatch that boxes
-    # its result (~16 bytes/call), adding per-step GC pressure (cf. issues #1/#3).
     rng::R
 
-    function SIRProcess(graph::AbstractEpidemicGraph, β::Float64, γ::Float64;
-                        rng::R = Random.default_rng()) where {R<:AbstractRNG}
+    function SIRProcess(graph::G, β::Float64, γ::Float64;
+                        rng::R = Random.default_rng()) where {G<:AbstractEpidemicGraph, R<:AbstractRNG}
         _validate_sir_parameters(β, γ)
-        new{R}(graph, β, γ, DictActiveTracker(), Set{Int}(), 0.0, 0, rng)
+        new{G,R}(graph, β, γ, DictActiveTracker(), Set{Int}(), 0.0, 0, rng)
     end
 end
 

--- a/src/models/zim.jl
+++ b/src/models/zim.jl
@@ -35,17 +35,20 @@ large-scale simulations on lattices and general graphs.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct ZIMProcess{R<:AbstractRNG} <: SIRLikeProcess
-    graph::AbstractEpidemicGraph
+mutable struct ZIMProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: SIRLikeProcess
+    # `graph` and `rng` are concrete type parameters rather than the abstract
+    # supertypes. Abstract fields would force every get_neighbors!/
+    # count_neighbors_by_state/rand call in step! through dynamic dispatch
+    # (preventing inlining of the small lattice routines), and rand() would
+    # additionally box its result (~16 bytes/call) — per-step overhead and GC
+    # pressure (cf. issues #1/#3).
+    graph::G
     λ::Float64
     μ::Float64
     infection_prob::Float64
     active_tracker::DictActiveTracker
     time::Float64
     steps::Int
-    # Parametric on the concrete RNG type: an abstract `rng::AbstractRNG` field
-    # would make every rand()/randexp() in step! a dynamic dispatch that boxes
-    # its result (~16 bytes/call), adding per-step GC pressure (cf. issues #1/#3).
     rng::R
     # Reusable scratch buffers for the per-step event handlers, so that stepping
     # allocates nothing on the hot path (see issues #1 / #3). neighbor_buf backs
@@ -55,8 +58,8 @@ mutable struct ZIMProcess{R<:AbstractRNG} <: SIRLikeProcess
     neighbor_buf::Vector{Int}
     susceptible_buf::Vector{Int}
 
-    function ZIMProcess(graph::AbstractEpidemicGraph, λ::Float64, μ::Float64 = 1.0;
-                       rng::R = Random.default_rng()) where {R<:AbstractRNG}
+    function ZIMProcess(graph::G, λ::Float64, μ::Float64 = 1.0;
+                       rng::R = Random.default_rng()) where {G<:AbstractEpidemicGraph, R<:AbstractRNG}
 
         _validate_zim_parameters(λ, μ)
 
@@ -68,7 +71,7 @@ mutable struct ZIMProcess{R<:AbstractRNG} <: SIRLikeProcess
         sizehint!(neighbor_buf, 8)
         sizehint!(susceptible_buf, 8)
 
-        new{R}(graph, λ, μ, infection_prob, active_tracker, 0.0, 0, rng,
+        new{G,R}(graph, λ, μ, infection_prob, active_tracker, 0.0, 0, rng,
             neighbor_buf, susceptible_buf)
     end
 end

--- a/src/models/zim.jl
+++ b/src/models/zim.jl
@@ -35,7 +35,7 @@ large-scale simulations on lattices and general graphs.
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
 """
-mutable struct ZIMProcess <: SIRLikeProcess
+mutable struct ZIMProcess{R<:AbstractRNG} <: SIRLikeProcess
     graph::AbstractEpidemicGraph
     λ::Float64
     μ::Float64
@@ -43,17 +43,33 @@ mutable struct ZIMProcess <: SIRLikeProcess
     active_tracker::DictActiveTracker
     time::Float64
     steps::Int
-    rng::AbstractRNG
-    
+    # Parametric on the concrete RNG type: an abstract `rng::AbstractRNG` field
+    # would make every rand()/randexp() in step! a dynamic dispatch that boxes
+    # its result (~16 bytes/call), adding per-step GC pressure (cf. issues #1/#3).
+    rng::R
+    # Reusable scratch buffers for the per-step event handlers, so that stepping
+    # allocates nothing on the hot path (see issues #1 / #3). neighbor_buf backs
+    # get_neighbors! calls; susceptible_buf collects susceptible neighbors when
+    # choosing an infection target. Each process is used by one thread at a time,
+    # so reuse is safe without locking.
+    neighbor_buf::Vector{Int}
+    susceptible_buf::Vector{Int}
+
     function ZIMProcess(graph::AbstractEpidemicGraph, λ::Float64, μ::Float64 = 1.0;
-                       rng::AbstractRNG = Random.default_rng())
-        
+                       rng::R = Random.default_rng()) where {R<:AbstractRNG}
+
         _validate_zim_parameters(λ, μ)
-        
+
         infection_prob = λ / (λ + μ)
         active_tracker = DictActiveTracker()
-        
-        new(graph, λ, μ, infection_prob, active_tracker, 0.0, 0, rng)
+
+        neighbor_buf = Int[]
+        susceptible_buf = Int[]
+        sizehint!(neighbor_buf, 8)
+        sizehint!(susceptible_buf, 8)
+
+        new{R}(graph, λ, μ, infection_prob, active_tracker, 0.0, 0, rng,
+            neighbor_buf, susceptible_buf)
     end
 end
 
@@ -173,27 +189,29 @@ This is the performance-critical function that implements your original algorith
 with efficient active node tracking updates.
 """
 function _zombie_wins!(process::ZIMProcess, zombie_node::Int)
-    # Get susceptible neighbors of the attacking zombie
-    neighbors = get_neighbors(process.graph, zombie_node)
+    # Get susceptible neighbors of the attacking zombie (neighbor_buf reused;
+    # may alias an internal list for non-lattice graphs, so treat it read-only).
+    neighbors = get_neighbors!(process.neighbor_buf, process.graph, zombie_node)
     states = node_states_raw(process.graph)
     susceptible_state = state_to_int(SUSCEPTIBLE)
     infected_state = state_to_int(INFECTED)
-    
-    # Find susceptible neighbors
-    susceptible_neighbors = Int[]
+
+    # Collect susceptible neighbors into the reused buffer (no allocation).
+    susceptible_neighbors = process.susceptible_buf
+    empty!(susceptible_neighbors)
     for neighbor in neighbors
         if states[neighbor] == susceptible_state
             push!(susceptible_neighbors, neighbor)
         end
     end
-    
+
     if isempty(susceptible_neighbors)
         # This shouldn't happen if active tracking is correct
         @warn "Zombie $zombie_node has no susceptible neighbors but is marked active"
         remove_active_node!(process.active_tracker, zombie_node)
         return
     end
-    
+
     # Randomly select a susceptible neighbor to infect
     target = rand(process.rng, susceptible_neighbors)
     states[target] = infected_state
@@ -232,7 +250,7 @@ function _update_active_tracking_after_infection!(process::ZIMProcess, attacking
     update_active_node!(process.active_tracker, attacking_zombie, current_count - 1)
     
     # 3. Update all zombie neighbors of the new zombie (they each lost a susceptible neighbor)
-    new_zombie_neighbors = get_neighbors(process.graph, new_zombie)
+    new_zombie_neighbors = get_neighbors!(process.neighbor_buf, process.graph, new_zombie)
     states = node_states_raw(process.graph)
     infected_state = state_to_int(INFECTED)
     
@@ -252,7 +270,7 @@ Update active tracking after a zombie death.
 """
 function _update_neighbors_after_zombie_death!(process::ZIMProcess, dead_zombie::Int)
     # Find all zombie neighbors of the dead zombie - they gain a susceptible "slot"
-    zombie_neighbors = get_neighbors(process.graph, dead_zombie)
+    zombie_neighbors = get_neighbors!(process.neighbor_buf, process.graph, dead_zombie)
     states = node_states_raw(process.graph)
     infected_state = state_to_int(INFECTED)
     
@@ -332,7 +350,7 @@ julia> results = run_simulation(zim; max_time=100.0, stop_on_escape=true)
 """
 function create_zim_simulation(graph::AbstractEpidemicGraph, λ::Float64, μ::Float64 = 1.0;
                               initial_infected::Union{Symbol, Vector{Int}} = :center,
-                              rng_seed::Union{Int, Nothing} = nothing)::ZIMProcess
+                              rng_seed::Union{Int, Nothing} = nothing)
     
     # Create RNG using utils.jl function
     rng = create_rng(rng_seed)
@@ -365,7 +383,7 @@ Convenience function for creating ZIM on square lattices (backward compatibility
 function create_zim_simulation(width::Int, height::Int, λ::Float64, μ::Float64 = 1.0;
                               boundary::Symbol = :absorbing,
                               initial_infected::Union{Symbol, Vector{Int}} = :center,
-                              rng_seed::Union{Int, Nothing} = nothing)::ZIMProcess
+                              rng_seed::Union{Int, Nothing} = nothing)
     
     lattice = create_square_lattice(width, height, boundary)
     return create_zim_simulation(lattice, λ, μ; initial_infected=initial_infected, rng_seed=rng_seed)

--- a/test/test_lattices.jl
+++ b/test/test_lattices.jl
@@ -157,6 +157,50 @@ end
             @test _stale_count(p) == 0
             @test GraphEpimodels.get_total_boundary(p.active_tracker) ==
                   sum(n -> count_neighbors_by_state(g, n, SUSCEPTIBLE), seeds)
+
+            # The invariant must survive a full run, not just the seeding. ZIM has
+            # a second event type (kill) that SIR lacks, so it needs its own
+            # full-run check; previously only the post-reset state was tested.
+            steps = 0
+            worst = 0
+            while is_active(p) && steps < 200_000
+                step!(p); steps += 1
+                worst = max(worst, _stale_count(p))
+            end
+            @test worst == 0
         end
+    end
+end
+
+# Weighted sampling must not depend on Dict iteration order. The active-node
+# tracker is a Dict, whose iteration order depends on insertion/deletion/rehash
+# history. If sampling walked that order, two trackers with identical contents
+# but different histories (a fresh process vs. one reused across simulations, or
+# per-thread processes that ran different work) would map the same random draw
+# onto different nodes — making results irreproducible between serial and
+# threaded runs. The sampler sorts into a canonical order to prevent this.
+@testset "weighted sampling is independent of Dict insertion order" begin
+    pairs = [(10, 3), (25, 1), (7, 4), (42, 2), (13, 5), (99, 1), (56, 3), (3, 2)]
+
+    t1 = GraphEpimodels.DictActiveTracker()
+    for (nd, w) in pairs
+        GraphEpimodels.add_active_node!(t1, nd, w)
+    end
+
+    # Same contents, but built in reverse order and churned to force a different
+    # internal hash-table layout.
+    t2 = GraphEpimodels.DictActiveTracker()
+    for (nd, w) in reverse(pairs)
+        GraphEpimodels.add_active_node!(t2, nd, w)
+    end
+    GraphEpimodels.add_active_node!(t2, 1000, 9)
+    GraphEpimodels.remove_active_node!(t2, 1000)
+
+    @test t1.active_nodes == t2.active_nodes  # equal contents...
+    n = length(pairs)
+    for seed in 1:100
+        a = GraphEpimodels._weighted_sample_active_fast(t1, n, MersenneTwister(seed))
+        b = GraphEpimodels._weighted_sample_active_fast(t2, n, MersenneTwister(seed))
+        @test a == b  # ...therefore identical selection for the same draw
     end
 end


### PR DESCRIPTION
Closes #1
Closes #3

## Summary

Investigation of issues #1 (weighted-sampling GC load) and #3 (threaded runs not parallelizing) grew into a hot-path overhaul. The root cause of #3 turned out to be the per-step heap allocations of #1: with many threads allocating continuously, Julia's stop-the-world GC phase serialized the workers (the "20% CPU" symptom). Removing those allocations, plus three related fixes uncovered along the way, is the bulk of this PR.

## What changed

**Allocation elimination (#1, #3)**
- `_weighted_sample_active_fast` reuses scratch buffers on the tracker instead of allocating three vectors per step (~45 KB/call at a ~1900-node boundary → **0**).
- New non-allocating `get_neighbors!(buffer, graph, node_id)` interface; ZIM event handlers reuse buffers instead of allocating neighbor/susceptible vectors each step.
- Overrides for all lattice types: square, adjacency, and (this PR) triangular/hexagonal — `get_neighbors!` is now 0 bytes/call everywhere (was ~144 bytes).
- Process structs parameterized on **both** RNG and graph type, so `rand()`/`randexp()` no longer box (~16 bytes/call each) and `step!` is fully type-stable (concrete return, concrete graph/rng fields → neighbor routines inline).

**Correctness**
- **Threaded reproducibility:** weighted sampling depended on `Dict` iteration order, so serial and threaded runs produced *different* survival counts for the same seeds. Now samples in canonical sorted order (in-place, still 0-alloc) → serial == threaded, bit-for-bit.
- **Threaded safety:** `_estimate_survival_threaded` indexed its process pool by `threadid()` under the default `:dynamic` schedule, where threadid is not stable across yield points (a migrated task could alias another's process). Pinned the loops to `:static`.

## Commits
1. `91ea5ae` Add non-allocating get_neighbors! graph interface
2. `891bc9e` Make weighted sampling allocation-free and deterministic
3. `4c699e4` Eliminate per-step allocations in process stepping
4. `8cd2a0a` Pin threaded survival loops to :static scheduling
5. `e9682da` Parameterize process structs on graph type
6. `5d4dec2` Add non-allocating get_neighbors! for triangular and hexagonal lattices

## Verification
- **Full suite: 410/410** with `-t 4` (added a ZIM full-run active-tracker invariant test and a Dict-order-independence regression test).
- Sampling hot path: **0 bytes/call**; `rand`/`randexp`: **0 bytes/call**; `get_neighbors!`: **0 bytes/call** on all lattice types.
- serial == threaded survival counts for identical seeds.

## Follow-ups (filed, not in this PR)
- #11 — residual ~243 B/step from `Dict` rehashing (sparse-set rewrite; gated on a GC measurement).
- #12 — `:static` load-balancing for heavy-tailed survival times (low priority / defer).

## Notes
- Scope is the simulation hot path; no behavioral/API changes beyond results now being reproducible across serial/threaded for a fixed seed (RNG draw sequence is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

