### PR TITLE
Fix transparent_background for square lattice plots

### DIFF
--- a/examples/transparent_demo.jl
+++ b/examples/transparent_demo.jl
@@ -1,0 +1,109 @@
+#!/usr/bin/env julia
+"""
+Demo script for issue #4 — transparent_background lattice plots.
+
+Generates six comparison PNGs in examples/transparent_demo/:
+  square_opaque.png        — square lattice, white background
+  square_transparent.png   — square lattice, transparent background (fixed)
+  tri_opaque.png           — triangular lattice, white background
+  tri_transparent.png      — triangular lattice, transparent background
+  hex_opaque.png           — hexagonal lattice, white background
+  hex_transparent.png      — hexagonal lattice, transparent background
+
+In each transparent PNG the susceptible cells carry alpha=0, so they are absent
+from the image. Open in any viewer that shows alpha (e.g. browser, Preview on
+macOS, IrfanView on Windows) to confirm susceptibles are truly transparent.
+
+Run from the project root:
+    julia --project examples/transparent_demo.jl
+"""
+
+using GraphEpimodels
+using CairoMakie
+using Random
+
+const OUTDIR = joinpath(@__DIR__, "transparent_demo")
+mkpath(OUTDIR)
+
+const SEED = 42
+
+# ---------------------------------------------------------------------------
+# Helper: run SIR until a good fraction is infected/removed, then snapshot.
+# ---------------------------------------------------------------------------
+
+function run_to_mid(process; target_removed_frac = 0.15)
+    n = num_nodes(get_graph(process))
+    while is_active(process)
+        step!(process)
+        s = get_statistics(process)
+        if s[:removed] >= target_removed_frac * n
+            break
+        end
+    end
+    return process
+end
+
+# ---------------------------------------------------------------------------
+# Square lattice (40 x 40)
+# ---------------------------------------------------------------------------
+
+println("Square lattice ...")
+
+sq = create_sir_simulation(40, 40, 4.0, 1.0; rng_seed = SEED)
+run_to_mid(sq)
+
+viz_sq = LatticeVisualizer(color_scheme = :sir, figure_size = (500, 500), show_grid = true)
+
+fig = visualize_state(viz_sq, sq; transparent_background = false)
+save(joinpath(OUTDIR, "square_opaque.png"), fig)
+
+fig = visualize_state(viz_sq, sq; transparent_background = true)
+save(joinpath(OUTDIR, "square_transparent.png"), fig)
+
+println("  -> square_opaque.png, square_transparent.png")
+
+# ---------------------------------------------------------------------------
+# Triangular lattice (35 x 35)
+# ---------------------------------------------------------------------------
+
+println("Triangular lattice ...")
+
+tri_graph = create_triangular_lattice(35, 35)
+tri = SIRProcess(tri_graph, 4.0, 1.0; rng = Random.MersenneTwister(SEED))
+reset!(tri, [num_nodes(tri_graph) ÷ 2]; rng_seed = SEED)
+run_to_mid(tri)
+
+viz_tri = LatticeVisualizer(color_scheme = :sir, figure_size = (500, 500), show_grid = true)
+
+fig = visualize_state(viz_tri, tri; transparent_background = false)
+save(joinpath(OUTDIR, "tri_opaque.png"), fig)
+
+fig = visualize_state(viz_tri, tri; transparent_background = true)
+save(joinpath(OUTDIR, "tri_transparent.png"), fig)
+
+println("  -> tri_opaque.png, tri_transparent.png")
+
+# ---------------------------------------------------------------------------
+# Hexagonal lattice (35 x 35)
+# ---------------------------------------------------------------------------
+
+println("Hexagonal lattice ...")
+
+hex_graph = create_hexagonal_lattice(35, 35)
+hex = SIRProcess(hex_graph, 4.0, 1.0; rng = Random.MersenneTwister(SEED))
+reset!(hex, [num_nodes(hex_graph) ÷ 2]; rng_seed = SEED)
+run_to_mid(hex)
+
+viz_hex = LatticeVisualizer(color_scheme = :sir, figure_size = (500, 500), show_grid = true)
+
+fig = visualize_state(viz_hex, hex; transparent_background = false)
+save(joinpath(OUTDIR, "hex_opaque.png"), fig)
+
+fig = visualize_state(viz_hex, hex; transparent_background = true)
+save(joinpath(OUTDIR, "hex_transparent.png"), fig)
+
+println("  -> hex_opaque.png, hex_transparent.png")
+
+println("\nAll plots written to: $OUTDIR")
+println("In the *_transparent.png files the susceptible cells should be")
+println("absent (alpha=0), leaving only infected (red) and removed (gray) visible.")

--- a/src/visualization/lattice_viz.jl
+++ b/src/visualization/lattice_viz.jl
@@ -102,7 +102,13 @@ function render_frame(viz::LatticeVisualizer, lattice::AbstractLatticeGraph,
     return fig
 end
 
-# Square lattice: fast path via a per-pixel color image.
+# Square lattice — two paths depending on whether transparency is needed.
+#
+# `image!` is fast but composites alpha against the Cairo surface before writing
+# pixels, so transparent susceptible cells (RGBAf(0,0,0,0)) appear as the
+# background colour rather than as true transparency in the saved PNG.
+# `poly!` renders each cell as a vector path fill; alpha=0 fills are genuinely
+# absent from the output, giving real per-cell transparency.
 function _draw_lattice!(ax, viz::LatticeVisualizer, lattice::SquareLattice,
                         states_raw::Vector{Int8}; transparent_background::Bool = false)
     width, height = lattice.width, lattice.height
@@ -110,14 +116,30 @@ function _draw_lattice!(ax, viz::LatticeVisualizer, lattice::SquareLattice,
                                transparent_background = transparent_background)
     palette = (cS, cI, cR)
 
-    # img[c, r] is the color at position (x = col, y = row).
-    img = Matrix{RGBAf}(undef, width, height)
-    @inbounds for idx in 1:lattice.n_nodes
-        r, c = index_to_coord(lattice, idx)
-        img[c, r] = palette[Int(states_raw[idx]) + 1]
+    if transparent_background
+        polys  = Vector{Vector{Point2f}}(undef, lattice.n_nodes)
+        colors = Vector{RGBAf}(undef, lattice.n_nodes)
+        @inbounds for idx in 1:lattice.n_nodes
+            r, c = index_to_coord(lattice, idx)
+            xf, yf = Float32(c), Float32(r)
+            polys[idx]  = [Point2f(xf - 0.5f0, yf - 0.5f0),
+                           Point2f(xf + 0.5f0, yf - 0.5f0),
+                           Point2f(xf + 0.5f0, yf + 0.5f0),
+                           Point2f(xf - 0.5f0, yf + 0.5f0)]
+            colors[idx] = palette[Int(states_raw[idx]) + 1]
+        end
+        strokewidth = viz.show_grid ? 0.5 : 0.0
+        poly!(ax, polys; color = colors, strokewidth = strokewidth,
+              strokecolor = (:gray, 0.5))
+    else
+        # Fast path via a per-pixel color image.
+        img = Matrix{RGBAf}(undef, width, height)
+        @inbounds for idx in 1:lattice.n_nodes
+            r, c = index_to_coord(lattice, idx)
+            img[c, r] = palette[Int(states_raw[idx]) + 1]
+        end
+        image!(ax, (0.5, width + 0.5), (0.5, height + 0.5), img; interpolate = false)
     end
-
-    image!(ax, (0.5, width + 0.5), (0.5, height + 0.5), img; interpolate = false)
 
     if viz.show_boundary && has_boundary(lattice)
         _draw_boundary_box!(ax, 0.5, width + 0.5, 0.5, height + 0.5)


### PR DESCRIPTION
## Summary

Fixes #4.

- `image!` in CairoMakie composites per-pixel alpha against the Cairo surface before writing, so `RGBAf(0,0,0,0)` susceptible cells rendered as the background colour rather than being truly absent from the saved PNG
- When `transparent_background=true`, the square lattice renderer now uses `poly!` with unit-square polygons (one per node) instead of the bitmap `image!` path
- The fast `image!` path is preserved for normal (opaque) renders — no performance change there
- Triangular and hexagonal lattices already used `poly!` and were unaffected

Also adds `examples/transparent_demo.jl`, which generates six comparison PNGs (opaque vs transparent for each lattice type) and was used to verify the fix.

## Test plan

- [x] Run `examples/transparent_demo.jl` and open the `*_transparent.png` outputs in a viewer that renders alpha (browser, Preview, IrfanView). Susceptible cells should be absent (truly transparent), leaving only infected (red) and removed (gray) visible.
- [x] Confirm `*_opaque.png` outputs look unchanged — white background, susceptibles as light blue.
- [x] Check that `show_grid=true` on a transparent plot shows cell outlines (nice side effect, confirmed working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)