### PR TITLE
Add structured graphs as implicit types (CompleteGraph, PathGraph, CycleGraph, StarGraph)

### DIFF
--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -85,16 +85,21 @@ export HexagonalLattice, create_hexagonal_lattice
 include("graphs/adjacency.jl")
 export AdjacencyGraph, set_coords!
 export create_graph_from_matrix, create_graph_from_edges
-export create_path_graph, create_cycle_graph, create_star_graph
 
 # Erdős–Rényi random graph (adjacency-list backed)
 include("graphs/erdos_renyi.jl")
 export ErdosRenyiGraph
 export create_erdos_renyi, create_gnp, create_gnm
 
-# Complete graph (implicit structured graph: stores only n)
+# Structured graphs as implicit types (store only n; neighbors computed on demand)
 include("graphs/complete.jl")
 export CompleteGraph, create_complete_graph
+include("graphs/path.jl")
+export PathGraph, create_path_graph
+include("graphs/cycle.jl")
+export CycleGraph, create_cycle_graph
+include("graphs/star.jl")
+export StarGraph, create_star_graph
 
 # =============================================================================
 # Epidemic Process Framework

--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -52,7 +52,7 @@ export Random
 
 # Abstract graph interface and core types
 include("graphs/graphs.jl")
-export AbstractEpidemicGraph, AbstractLatticeGraph
+export AbstractEpidemicGraph, AbstractImplicitGraph, AbstractLatticeGraph
 export NodeState, SUSCEPTIBLE, INFECTED, REMOVED, S, I, R
 export BoundaryCondition, ABSORBING, PERIODIC
 export state_to_int, int_to_state
@@ -85,12 +85,16 @@ export HexagonalLattice, create_hexagonal_lattice
 include("graphs/adjacency.jl")
 export AdjacencyGraph, set_coords!
 export create_graph_from_matrix, create_graph_from_edges
-export create_complete_graph, create_path_graph, create_cycle_graph, create_star_graph
+export create_path_graph, create_cycle_graph, create_star_graph
 
 # Erdős–Rényi random graph (adjacency-list backed)
 include("graphs/erdos_renyi.jl")
 export ErdosRenyiGraph
 export create_erdos_renyi, create_gnp, create_gnm
+
+# Complete graph (implicit structured graph: stores only n)
+include("graphs/complete.jl")
+export CompleteGraph, create_complete_graph
 
 # =============================================================================
 # Epidemic Process Framework

--- a/src/graphs/adjacency.jl
+++ b/src/graphs/adjacency.jl
@@ -287,111 +287,12 @@ function create_graph_from_edges(n_nodes::Int, edges::Vector{Tuple{Int, Int}};
     return AdjacencyGraph(adjacency_list; coords = coords)
 end
 
-# `create_complete_graph` lives in `complete.jl`: the complete graph has a
-# dedicated implicit type (`CompleteGraph`) that stores only `n`, rather than a
-# materialized O(n²) adjacency list.
-
-"""
-Create path graph (nodes connected in a line: 1-2-3-...-n).
-
-# Arguments
-- `n::Int`: Number of nodes
-
-# Returns
-- `AdjacencyGraph`: Path graph
-
-# Example
-```julia
-julia> path = create_path_graph(100)  # Linear chain
-```
-"""
-function create_path_graph(n::Int)::AdjacencyGraph
-    if n < 1
-        throw(ArgumentError("Number of nodes must be positive"))
-    end
-    
-    adjacency_list = Vector{Vector{Int}}(undef, n)
-    
-    for i in 1:n
-        neighbors = Int[]
-        if i > 1
-            push!(neighbors, i-1)
-        end
-        if i < n
-            push!(neighbors, i+1)
-        end
-        adjacency_list[i] = neighbors
-    end
-    
-    return AdjacencyGraph(adjacency_list)
-end
-
-"""
-Create cycle graph (path with ends connected: 1-2-3-...-n-1).
-
-# Arguments
-- `n::Int`: Number of nodes
-
-# Returns
-- `AdjacencyGraph`: Cycle graph
-
-# Example
-```julia
-julia> cycle = create_cycle_graph(10)  # 10-node ring
-```
-"""
-function create_cycle_graph(n::Int)::AdjacencyGraph
-    if n < 3
-        throw(ArgumentError("Cycle graph needs at least 3 nodes"))
-    end
-    
-    adjacency_list = Vector{Vector{Int}}(undef, n)
-    
-    for i in 1:n
-        neighbors = Int[]
-        # Previous node (with wraparound)
-        prev = i == 1 ? n : i - 1
-        push!(neighbors, prev)
-        # Next node (with wraparound)
-        next = i == n ? 1 : i + 1
-        push!(neighbors, next)
-        adjacency_list[i] = neighbors
-    end
-    
-    return AdjacencyGraph(adjacency_list)
-end
-
-"""
-Create star graph (one central node connected to all others).
-
-# Arguments
-- `n::Int`: Total number of nodes
-
-# Returns  
-- `AdjacencyGraph`: Star graph (node 1 is the center)
-
-# Example
-```julia
-julia> star = create_star_graph(6)  # 1 center + 5 leaves
-```
-"""
-function create_star_graph(n::Int)::AdjacencyGraph
-    if n < 2
-        throw(ArgumentError("Star graph needs at least 2 nodes"))
-    end
-    
-    adjacency_list = Vector{Vector{Int}}(undef, n)
-    
-    # Center node (node 1) connects to all others
-    adjacency_list[1] = collect(2:n)
-    
-    # All other nodes connect only to center
-    for i in 2:n
-        adjacency_list[i] = [1]
-    end
-    
-    return AdjacencyGraph(adjacency_list)
-end
+# The named structured graphs each have a dedicated implicit type that stores only
+# `n` (neighbors computed on demand), rather than a materialized adjacency list:
+#   create_complete_graph -> CompleteGraph (graphs/complete.jl)
+#   create_path_graph      -> PathGraph     (graphs/path.jl)
+#   create_cycle_graph     -> CycleGraph    (graphs/cycle.jl)
+#   create_star_graph      -> StarGraph     (graphs/star.jl)
 
 # Erdős–Rényi random graphs live in their own type/file (graphs/erdos_renyi.jl):
 # create_erdos_renyi / create_gnp / create_gnm return an ErdosRenyiGraph.

--- a/src/graphs/adjacency.jl
+++ b/src/graphs/adjacency.jl
@@ -287,36 +287,9 @@ function create_graph_from_edges(n_nodes::Int, edges::Vector{Tuple{Int, Int}};
     return AdjacencyGraph(adjacency_list; coords = coords)
 end
 
-"""
-Create complete graph (all nodes connected to all others).
-
-# Arguments
-- `n::Int`: Number of nodes
-
-# Returns
-- `AdjacencyGraph`: Complete graph
-
-# Example
-```julia
-julia> complete = create_complete_graph(5)  # K_5
-```
-"""
-function create_complete_graph(n::Int)::AdjacencyGraph
-    if n < 1
-        throw(ArgumentError("Number of nodes must be positive"))
-    end
-    if n > 10_000
-        @warn "Creating complete graph with $n nodes ($(n*(n-1)÷2) edges) - this may use significant memory"
-    end
-    
-    adjacency_list = Vector{Vector{Int}}(undef, n)
-    
-    for i in 1:n
-        adjacency_list[i] = [j for j in 1:n if j != i]
-    end
-    
-    return AdjacencyGraph(adjacency_list)
-end
+# `create_complete_graph` lives in `complete.jl`: the complete graph has a
+# dedicated implicit type (`CompleteGraph`) that stores only `n`, rather than a
+# materialized O(n²) adjacency list.
 
 """
 Create path graph (nodes connected in a line: 1-2-3-...-n).

--- a/src/graphs/complete.jl
+++ b/src/graphs/complete.jl
@@ -1,0 +1,160 @@
+"""
+Complete graph implementation for epidemic modeling.
+
+A *complete graph* `K_n` connects every pair of distinct nodes. Its connectivity
+is fully determined by `n`, so it is an [`AbstractImplicitGraph`](@ref): neighbors
+are computed by arithmetic on demand and never stored. This makes the structure
+O(n) memory instead of the O(n²) a materialized adjacency list would cost —
+`K_n` has `n(n-1)/2` edges, so the explicit form is infeasible past a few
+thousand nodes (a 50,000-node `K_n` would store 2.5 billion neighbor entries).
+
+Neighbor counting by state is the simulation hot path. For a complete graph every
+node sees all others, so the count of a node's neighbors in some state is just the
+global count of that state minus the node itself — an allocation-free linear scan
+of the contiguous `Int8` state array, with no adjacency list to gather over.
+"""
+
+using Random
+
+# Import the graph interface (assumes graphs.jl is loaded first).
+
+# =============================================================================
+# Complete Graph
+# =============================================================================
+
+"""
+Complete graph `K_n`: every node is adjacent to every other node.
+
+Stores only the node count and the primitive `Int8` state vector; neighbors are
+computed on demand (see the file header). All state operations use primitive
+arrays for maximum performance, matching the rest of the package.
+
+# Fields
+- `n_nodes::Int`: Number of nodes
+- `states::Vector{Int8}`: Node states (primitive array)
+"""
+mutable struct CompleteGraph <: AbstractImplicitGraph
+    n_nodes::Int
+    states::Vector{Int8}
+
+    function CompleteGraph(n::Int)
+        if n < 1
+            throw(ArgumentError("Number of nodes must be positive"))
+        end
+        new(n, zeros(Int8, n))  # All start SUSCEPTIBLE
+    end
+end
+
+# =============================================================================
+# Core Interface Implementation (Required Methods)
+# =============================================================================
+
+@inline function num_nodes(graph::CompleteGraph)::Int
+    return graph.n_nodes
+end
+
+function node_states_raw(graph::CompleteGraph)::Vector{Int8}
+    return graph.states
+end
+
+function set_node_states_raw!(graph::CompleteGraph, states::Vector{Int8})
+    if length(states) != num_nodes(graph)
+        throw(ArgumentError("Expected $(num_nodes(graph)) states, got $(length(states))"))
+    end
+    graph.states = states
+end
+
+function get_neighbors(graph::CompleteGraph, node_id::Int)::Vector{Int}
+    return get_neighbors!(Int[], graph, node_id)
+end
+
+function get_neighbors!(neighbors::Vector{Int}, graph::CompleteGraph, node_id::Int)::Vector{Int}
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    empty!(neighbors)
+    sizehint!(neighbors, n - 1)
+    @inbounds for j in 1:n
+        if j != node_id
+            push!(neighbors, j)
+        end
+    end
+    return neighbors
+end
+
+# Degree is constant: every node connects to all n-1 others.
+@inline function get_node_degree(graph::CompleteGraph, node_id::Int)::Int
+    if node_id < 1 || node_id > graph.n_nodes
+        throw(BoundsError("Node ID $node_id out of range [1, $(graph.n_nodes)]"))
+    end
+    return graph.n_nodes - 1
+end
+
+# =============================================================================
+# Performance-Optimized Neighbor Counting
+# =============================================================================
+
+"""
+Optimized neighbor counting for the complete graph.
+
+Every node neighbors every other node, so the number of a node's neighbors in
+`target_state` is the global count of that state, minus one if the node itself is
+in that state. This is an allocation-free linear scan of the contiguous state
+array — no adjacency list is materialized.
+"""
+function count_neighbors_by_state(graph::CompleteGraph, node_id::Int,
+                                  target_state::NodeState)::Int
+    if node_id < 1 || node_id > graph.n_nodes
+        throw(BoundsError("Node ID $node_id out of range [1, $(graph.n_nodes)]"))
+    end
+    target_int = state_to_int(target_state)
+    total = count(==(target_int), graph.states)
+    # Exclude the node itself (a node is not its own neighbor).
+    @inbounds return total - (graph.states[node_id] == target_int ? 1 : 0)
+end
+
+# =============================================================================
+# Geometry Interface (for visualization)
+# =============================================================================
+#
+# A complete graph has no intrinsic embedding, but the conventional drawing places
+# the nodes evenly on a circle so every edge is visible. Providing this gives a
+# deterministic layout instead of falling back to a computed (force-directed) one.
+# It is not a space-filling tiling, so it supplies no cells.
+
+has_layout(::CompleteGraph)::Bool = true
+layout_dim(::CompleteGraph)::Int = 2
+
+function node_positions(graph::CompleteGraph)::Matrix{Float64}
+    n = graph.n_nodes
+    pos = Matrix{Float64}(undef, 2, n)
+    @inbounds for idx in 1:n
+        θ = 2π * (idx - 1) / n
+        pos[1, idx] = cos(θ)
+        pos[2, idx] = sin(θ)
+    end
+    return pos
+end
+
+# =============================================================================
+# Factory Function
+# =============================================================================
+
+"""
+Create complete graph (all nodes connected to all others).
+
+# Arguments
+- `n::Int`: Number of nodes
+
+# Returns
+- `CompleteGraph`: Complete graph `K_n`
+
+# Example
+```julia
+julia> complete = create_complete_graph(5)  # K_5
+```
+"""
+function create_complete_graph(n::Int)::CompleteGraph
+    return CompleteGraph(n)
+end

--- a/src/graphs/cycle.jl
+++ b/src/graphs/cycle.jl
@@ -1,0 +1,150 @@
+"""
+Cycle graph implementation for epidemic modeling.
+
+A *cycle graph* `C_n` is a path with its ends joined: `1 - 2 - … - n - 1`. Its
+connectivity is fully determined by `n`, so it is an [`AbstractImplicitGraph`](@ref):
+a node's two neighbors (the previous and next index, with wraparound) are computed
+by arithmetic on demand rather than stored. Every node has degree 2.
+"""
+
+using Random
+
+# =============================================================================
+# Cycle Graph
+# =============================================================================
+
+"""
+Cycle graph `C_n`: a ring `1 - 2 - … - n - 1` (every node has degree 2).
+
+Stores only the node count and the primitive `Int8` state vector; neighbors are
+computed on demand.
+
+# Fields
+- `n_nodes::Int`: Number of nodes
+- `states::Vector{Int8}`: Node states (primitive array)
+"""
+mutable struct CycleGraph <: AbstractImplicitGraph
+    n_nodes::Int
+    states::Vector{Int8}
+
+    function CycleGraph(n::Int)
+        if n < 3
+            throw(ArgumentError("Cycle graph needs at least 3 nodes"))
+        end
+        new(n, zeros(Int8, n))  # All start SUSCEPTIBLE
+    end
+end
+
+# Previous / next index on the ring (1-indexed, with wraparound).
+@inline _cycle_prev(node_id::Int, n::Int)::Int = node_id == 1 ? n : node_id - 1
+@inline _cycle_next(node_id::Int, n::Int)::Int = node_id == n ? 1 : node_id + 1
+
+# =============================================================================
+# Core Interface Implementation (Required Methods)
+# =============================================================================
+
+@inline function num_nodes(graph::CycleGraph)::Int
+    return graph.n_nodes
+end
+
+function node_states_raw(graph::CycleGraph)::Vector{Int8}
+    return graph.states
+end
+
+function set_node_states_raw!(graph::CycleGraph, states::Vector{Int8})
+    if length(states) != num_nodes(graph)
+        throw(ArgumentError("Expected $(num_nodes(graph)) states, got $(length(states))"))
+    end
+    graph.states = states
+end
+
+function get_neighbors(graph::CycleGraph, node_id::Int)::Vector{Int}
+    return get_neighbors!(Int[], graph, node_id)
+end
+
+function get_neighbors!(neighbors::Vector{Int}, graph::CycleGraph, node_id::Int)::Vector{Int}
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    empty!(neighbors)
+    push!(neighbors, _cycle_prev(node_id, n))
+    push!(neighbors, _cycle_next(node_id, n))
+    return neighbors
+end
+
+# Degree is constant: every node on the ring has exactly 2 neighbors.
+@inline function get_node_degree(graph::CycleGraph, node_id::Int)::Int
+    if node_id < 1 || node_id > graph.n_nodes
+        throw(BoundsError("Node ID $node_id out of range [1, $(graph.n_nodes)]"))
+    end
+    return 2
+end
+
+# =============================================================================
+# Performance-Optimized Neighbor Counting
+# =============================================================================
+
+"""
+Allocation-free neighbor counting for a cycle: check the two adjacent indices
+(with wraparound) directly instead of materializing a neighbor list. `n >= 3`
+guarantees the two neighbors are distinct.
+"""
+function count_neighbors_by_state(graph::CycleGraph, node_id::Int,
+                                  target_state::NodeState)::Int
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    states = graph.states
+    target_int = state_to_int(target_state)
+    count = 0
+    @inbounds begin
+        states[_cycle_prev(node_id, n)] == target_int && (count += 1)
+        states[_cycle_next(node_id, n)] == target_int && (count += 1)
+    end
+    return count
+end
+
+# =============================================================================
+# Geometry Interface (for visualization)
+# =============================================================================
+#
+# A cycle is drawn with its nodes evenly spaced on the unit circle, so adjacent
+# indices are adjacent on the ring. It is not a space-filling tiling (no cells).
+
+has_layout(::CycleGraph)::Bool = true
+layout_dim(::CycleGraph)::Int = 2
+
+function node_positions(graph::CycleGraph)::Matrix{Float64}
+    n = graph.n_nodes
+    pos = Matrix{Float64}(undef, 2, n)
+    @inbounds for idx in 1:n
+        θ = 2π * (idx - 1) / n
+        pos[1, idx] = cos(θ)
+        pos[2, idx] = sin(θ)
+    end
+    return pos
+end
+
+# =============================================================================
+# Factory Function
+# =============================================================================
+
+"""
+Create cycle graph (path with ends connected: 1-2-3-...-n-1).
+
+# Arguments
+- `n::Int`: Number of nodes
+
+# Returns
+- `CycleGraph`: Cycle graph `C_n`
+
+# Example
+```julia
+julia> cycle = create_cycle_graph(10)  # 10-node ring
+```
+"""
+function create_cycle_graph(n::Int)::CycleGraph
+    return CycleGraph(n)
+end

--- a/src/graphs/erdos_renyi.jl
+++ b/src/graphs/erdos_renyi.jl
@@ -189,6 +189,25 @@ end
 # Public constructors
 # =============================================================================
 
+# Above this node count, materializing the complete graph (the degenerate p == 1 /
+# m == n(n-1)/2 case) costs enough memory to be worth flagging — the same threshold
+# the former create_complete_graph used.
+const _COMPLETE_FALLBACK_WARN_N = 10_000
+
+"""
+Warn (once) when Erdős–Rényi parameters select the complete graph at a size where
+the O(n²) adjacency-list materialization is costly, pointing to the dedicated
+[`CompleteGraph`](@ref) type.
+"""
+function _warn_complete_fallback(n::Int)
+    n > _COMPLETE_FALLBACK_WARN_N && @warn(
+        "Erdős–Rényi parameters select the complete graph K_$n, built here as a " *
+        "materialized O(n²) adjacency list. For a complete graph, prefer the " *
+        "dedicated CompleteGraph type (create_complete_graph), which stores only n.",
+        maxlog = 1)
+    return nothing
+end
+
 """
 Create an Erdős–Rényi random graph.
 
@@ -208,6 +227,12 @@ Provide **exactly one** of `p` (the G(n, p) model) or `m` (the G(n, m) model).
 julia> g = create_erdos_renyi(100; p = 0.1)        # G(n, p)
 julia> h = create_erdos_renyi(100; m = 250)        # G(n, m)
 ```
+
+# Note
+The degenerate cases `p == 1` and `m == n(n-1)/2` yield the complete graph,
+materialized as an O(n²) adjacency list. If you specifically want `K_n`, prefer
+the dedicated [`CompleteGraph`](@ref) type (`create_complete_graph`), which stores
+only `n`; at large `n` these cases emit a one-time warning.
 """
 function create_erdos_renyi(n::Int;
                             p::Union{Real, Nothing} = nothing,
@@ -222,11 +247,13 @@ function create_erdos_renyi(n::Int;
     if p !== nothing
         (0.0 <= p <= 1.0) ||
             throw(ArgumentError("Edge probability p must be in [0, 1] (got $p)"))
+        Float64(p) >= 1.0 && _warn_complete_fallback(n)
         graph = AdjacencyGraph(_erdos_renyi_gnp(n, Float64(p), rng))
         realized_m = sum(graph.node_degrees) ÷ 2
         return ErdosRenyiGraph(graph, :gnp, Float64(p), realized_m)
     else
         m >= 0 || throw(ArgumentError("Edge count m must be non-negative (got $m)"))
+        Int(m) == total && _warn_complete_fallback(n)
         graph = AdjacencyGraph(_erdos_renyi_gnm(n, Int(m), rng))   # validates m ≤ total
         density = total == 0 ? 0.0 : m / total
         return ErdosRenyiGraph(graph, :gnm, density, Int(m))

--- a/src/graphs/graphs.jl
+++ b/src/graphs/graphs.jl
@@ -42,19 +42,30 @@ This design allows epidemic processes to work with any graph structure
 abstract type AbstractEpidemicGraph end
 
 """
-Abstract base type for regular lattice graphs (square, triangular, hexagonal).
+Abstract base type for *implicit* graphs, whose connectivity is a closed-form
+function of the node index rather than stored data.
 
-Lattice graphs share a key property: their connectivity is *implicit* in a
-regular geometric arrangement, so neighbors are computed by O(1) coordinate
-arithmetic rather than stored as explicit adjacency lists. They also carry an
-intrinsic spatial layout (see the geometry interface below), which the
-visualization layer uses to draw them as dual-tiling cells.
+Implicit graphs compute a node's neighbors by arithmetic on demand and never
+materialize an adjacency list, so their structure costs O(n) memory (just the
+state vector) instead of O(n + m). This is the right category for any graph
+family with a regular, parametrized topology — lattices (square, triangular,
+hexagonal) and structured graphs like the complete graph.
 
-This is a sibling of `AdjacencyGraph` (which stores explicit adjacency lists and
-has no intrinsic geometry), not a supertype of it: lattices deliberately avoid
+This is a sibling of `AdjacencyGraph` (which stores explicit adjacency lists for
+arbitrary topologies), not a supertype of it: implicit graphs deliberately avoid
 materializing adjacency lists.
 """
-abstract type AbstractLatticeGraph <: AbstractEpidemicGraph end
+abstract type AbstractImplicitGraph <: AbstractEpidemicGraph end
+
+"""
+Abstract base type for regular lattice graphs (square, triangular, hexagonal).
+
+Lattices are [`AbstractImplicitGraph`](@ref)s whose implicit structure is a
+*regular geometric arrangement*: neighbors are computed by O(1) coordinate
+arithmetic, and they carry an intrinsic spatial layout (see the geometry
+interface below) that the visualization layer draws as dual-tiling cells.
+"""
+abstract type AbstractLatticeGraph <: AbstractImplicitGraph end
 
 """
 Pre-compute the perimeter node indices of a `width × height` rectangular array.

--- a/src/graphs/path.jl
+++ b/src/graphs/path.jl
@@ -1,0 +1,150 @@
+"""
+Path graph implementation for epidemic modeling.
+
+A *path graph* `P_n` connects nodes in a line: `1 - 2 - 3 - … - n`. Its
+connectivity is fully determined by `n`, so it is an [`AbstractImplicitGraph`](@ref):
+a node's neighbors (`i-1` and `i+1`, where they exist) are computed by arithmetic
+on demand rather than stored. The two endpoints have degree 1; interior nodes have
+degree 2.
+"""
+
+using Random
+
+# =============================================================================
+# Path Graph
+# =============================================================================
+
+"""
+Path graph `P_n`: nodes connected in a line `1 - 2 - … - n`.
+
+Stores only the node count and the primitive `Int8` state vector; neighbors are
+computed on demand.
+
+# Fields
+- `n_nodes::Int`: Number of nodes
+- `states::Vector{Int8}`: Node states (primitive array)
+"""
+mutable struct PathGraph <: AbstractImplicitGraph
+    n_nodes::Int
+    states::Vector{Int8}
+
+    function PathGraph(n::Int)
+        if n < 1
+            throw(ArgumentError("Number of nodes must be positive"))
+        end
+        new(n, zeros(Int8, n))  # All start SUSCEPTIBLE
+    end
+end
+
+# =============================================================================
+# Core Interface Implementation (Required Methods)
+# =============================================================================
+
+@inline function num_nodes(graph::PathGraph)::Int
+    return graph.n_nodes
+end
+
+function node_states_raw(graph::PathGraph)::Vector{Int8}
+    return graph.states
+end
+
+function set_node_states_raw!(graph::PathGraph, states::Vector{Int8})
+    if length(states) != num_nodes(graph)
+        throw(ArgumentError("Expected $(num_nodes(graph)) states, got $(length(states))"))
+    end
+    graph.states = states
+end
+
+function get_neighbors(graph::PathGraph, node_id::Int)::Vector{Int}
+    return get_neighbors!(Int[], graph, node_id)
+end
+
+function get_neighbors!(neighbors::Vector{Int}, graph::PathGraph, node_id::Int)::Vector{Int}
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    empty!(neighbors)
+    node_id > 1 && push!(neighbors, node_id - 1)
+    node_id < n && push!(neighbors, node_id + 1)
+    return neighbors
+end
+
+# Degree: 1 at the two endpoints, 2 in the interior.
+@inline function get_node_degree(graph::PathGraph, node_id::Int)::Int
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    return (node_id > 1) + (node_id < n)
+end
+
+# =============================================================================
+# Performance-Optimized Neighbor Counting
+# =============================================================================
+
+"""
+Allocation-free neighbor counting for a path: check the at-most-two adjacent
+indices directly instead of materializing a neighbor list.
+"""
+function count_neighbors_by_state(graph::PathGraph, node_id::Int,
+                                  target_state::NodeState)::Int
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    states = graph.states
+    target_int = state_to_int(target_state)
+    count = 0
+    @inbounds begin
+        if node_id > 1 && states[node_id - 1] == target_int
+            count += 1
+        end
+        if node_id < n && states[node_id + 1] == target_int
+            count += 1
+        end
+    end
+    return count
+end
+
+# =============================================================================
+# Geometry Interface (for visualization)
+# =============================================================================
+#
+# A path is drawn as collinear nodes: node i sits at (i, 0). It is not a
+# space-filling tiling, so it supplies no cells.
+
+has_layout(::PathGraph)::Bool = true
+layout_dim(::PathGraph)::Int = 2
+
+function node_positions(graph::PathGraph)::Matrix{Float64}
+    n = graph.n_nodes
+    pos = Matrix{Float64}(undef, 2, n)
+    @inbounds for idx in 1:n
+        pos[1, idx] = Float64(idx)
+        pos[2, idx] = 0.0
+    end
+    return pos
+end
+
+# =============================================================================
+# Factory Function
+# =============================================================================
+
+"""
+Create path graph (nodes connected in a line: 1-2-3-...-n).
+
+# Arguments
+- `n::Int`: Number of nodes
+
+# Returns
+- `PathGraph`: Path graph `P_n`
+
+# Example
+```julia
+julia> path = create_path_graph(100)  # Linear chain
+```
+"""
+function create_path_graph(n::Int)::PathGraph
+    return PathGraph(n)
+end

--- a/src/graphs/star.jl
+++ b/src/graphs/star.jl
@@ -1,0 +1,168 @@
+"""
+Star graph implementation for epidemic modeling.
+
+A *star graph* `S_n` has one central node (node 1) connected to every other node,
+and the `n-1` leaves connected only to the center. Its connectivity is fully
+determined by `n`, so it is an [`AbstractImplicitGraph`](@ref): neighbors are
+computed on demand rather than stored. The center has degree `n-1`; every leaf has
+degree 1.
+
+Like the complete graph, the center neighbors every other node, so the center's
+neighbor-by-state count is the global state count minus the center itself — an
+allocation-free scan with no adjacency list (see `count_neighbors_by_state`).
+"""
+
+using Random
+
+# =============================================================================
+# Star Graph
+# =============================================================================
+
+"""
+Star graph `S_n`: central node 1 connected to all others; leaves connect only to
+the center.
+
+Stores only the node count and the primitive `Int8` state vector; neighbors are
+computed on demand.
+
+# Fields
+- `n_nodes::Int`: Number of nodes (1 center + `n-1` leaves)
+- `states::Vector{Int8}`: Node states (primitive array)
+"""
+mutable struct StarGraph <: AbstractImplicitGraph
+    n_nodes::Int
+    states::Vector{Int8}
+
+    function StarGraph(n::Int)
+        if n < 2
+            throw(ArgumentError("Star graph needs at least 2 nodes"))
+        end
+        new(n, zeros(Int8, n))  # All start SUSCEPTIBLE
+    end
+end
+
+# =============================================================================
+# Core Interface Implementation (Required Methods)
+# =============================================================================
+
+@inline function num_nodes(graph::StarGraph)::Int
+    return graph.n_nodes
+end
+
+function node_states_raw(graph::StarGraph)::Vector{Int8}
+    return graph.states
+end
+
+function set_node_states_raw!(graph::StarGraph, states::Vector{Int8})
+    if length(states) != num_nodes(graph)
+        throw(ArgumentError("Expected $(num_nodes(graph)) states, got $(length(states))"))
+    end
+    graph.states = states
+end
+
+function get_neighbors(graph::StarGraph, node_id::Int)::Vector{Int}
+    return get_neighbors!(Int[], graph, node_id)
+end
+
+function get_neighbors!(neighbors::Vector{Int}, graph::StarGraph, node_id::Int)::Vector{Int}
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    empty!(neighbors)
+    if node_id == 1
+        # Center: every leaf (nodes 2..n).
+        sizehint!(neighbors, n - 1)
+        @inbounds for j in 2:n
+            push!(neighbors, j)
+        end
+    else
+        # Leaf: only the center.
+        push!(neighbors, 1)
+    end
+    return neighbors
+end
+
+# Degree: n-1 at the center (node 1), 1 at every leaf.
+@inline function get_node_degree(graph::StarGraph, node_id::Int)::Int
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    return node_id == 1 ? n - 1 : 1
+end
+
+# =============================================================================
+# Performance-Optimized Neighbor Counting
+# =============================================================================
+
+"""
+Allocation-free neighbor counting for a star.
+
+- A leaf has the single neighbor `1` (the center), so the count is whether the
+  center is in `target_state`.
+- The center neighbors every leaf, so the count is the global number of nodes in
+  `target_state`, minus the center itself if it is in that state.
+"""
+function count_neighbors_by_state(graph::StarGraph, node_id::Int,
+                                  target_state::NodeState)::Int
+    n = graph.n_nodes
+    if node_id < 1 || node_id > n
+        throw(BoundsError("Node ID $node_id out of range [1, $n]"))
+    end
+    states = graph.states
+    target_int = state_to_int(target_state)
+    if node_id != 1
+        @inbounds return states[1] == target_int ? 1 : 0
+    end
+    # Center: all leaves = every node except the center.
+    total = count(==(target_int), states)
+    @inbounds return total - (states[1] == target_int ? 1 : 0)
+end
+
+# =============================================================================
+# Geometry Interface (for visualization)
+# =============================================================================
+#
+# The center sits at the origin and the leaves are spread evenly on the unit
+# circle around it. It is not a space-filling tiling, so it supplies no cells.
+
+has_layout(::StarGraph)::Bool = true
+layout_dim(::StarGraph)::Int = 2
+
+function node_positions(graph::StarGraph)::Matrix{Float64}
+    n = graph.n_nodes
+    pos = Matrix{Float64}(undef, 2, n)
+    @inbounds begin
+        pos[1, 1] = 0.0
+        pos[2, 1] = 0.0
+        for idx in 2:n
+            θ = 2π * (idx - 2) / (n - 1)
+            pos[1, idx] = cos(θ)
+            pos[2, idx] = sin(θ)
+        end
+    end
+    return pos
+end
+
+# =============================================================================
+# Factory Function
+# =============================================================================
+
+"""
+Create star graph (one central node connected to all others).
+
+# Arguments
+- `n::Int`: Total number of nodes (node 1 is the center)
+
+# Returns
+- `StarGraph`: Star graph `S_n`
+
+# Example
+```julia
+julia> star = create_star_graph(6)  # 1 center + 5 leaves
+```
+"""
+function create_star_graph(n::Int)::StarGraph
+    return StarGraph(n)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,5 @@ using Random
     include("test_lattices.jl")
     include("test_erdos_renyi.jl")
     include("test_complete_graph.jl")
+    include("test_structured_graphs.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ using Random
     include("test_chasescape.jl")
     include("test_lattices.jl")
     include("test_erdos_renyi.jl")
+    include("test_complete_graph.jl")
 end

--- a/test/test_complete_graph.jl
+++ b/test/test_complete_graph.jl
@@ -1,0 +1,115 @@
+using Test
+using GraphEpimodels
+using Random
+
+# Reference complete-graph neighbors: everyone except the node itself.
+_ref_neighbors(n, i) = [j for j in 1:n if j != i]
+
+# Generic (interface-level) neighbor-by-state count, used as an oracle for the
+# CompleteGraph override.
+function _generic_count(g, node_id, state)
+    states = node_states_raw(g)
+    target = state_to_int(state)
+    # `count` (unlike `sum(... for ...)`) returns 0 on an empty neighbor set,
+    # e.g. the single-node complete graph.
+    count(j -> states[j] == target, get_neighbors(g, node_id))
+end
+
+@testset "CompleteGraph" begin
+    @testset "type and construction" begin
+        g = create_complete_graph(6)
+        @test g isa CompleteGraph
+        @test g isa AbstractImplicitGraph
+        @test g isa AbstractEpidemicGraph
+        # Implicit graphs are siblings of AdjacencyGraph, not subtypes.
+        @test !(g isa AbstractLatticeGraph)
+        @test num_nodes(g) == 6
+
+        @test_throws ArgumentError create_complete_graph(0)
+        @test_throws ArgumentError create_complete_graph(-3)
+    end
+
+    @testset "topology" begin
+        n = 7
+        g = create_complete_graph(n)
+        for i in 1:n
+            nb = get_neighbors(g, i)
+            @test Set(nb) == Set(_ref_neighbors(n, i))   # all others
+            @test i ∉ nb                                  # no self-loop
+            @test length(nb) == length(unique(nb))        # no duplicates
+            @test length(nb) == n - 1
+            @test get_node_degree(g, i) == n - 1
+        end
+        # Every edge is mirrored (undirected).
+        for i in 1:n, j in get_neighbors(g, i)
+            @test i in get_neighbors(g, j)
+        end
+        @test_throws BoundsError get_neighbors(g, 0)
+        @test_throws BoundsError get_neighbors(g, n + 1)
+
+        # Single-node complete graph: valid, no neighbors.
+        g1 = create_complete_graph(1)
+        @test num_nodes(g1) == 1
+        @test isempty(get_neighbors(g1, 1))
+    end
+
+    @testset "get_neighbors! reuses the buffer" begin
+        g = create_complete_graph(5)
+        buf = Int[]
+        out = get_neighbors!(buf, g, 2)
+        @test out === buf                        # filled in place, no allocation
+        @test Set(out) == Set(_ref_neighbors(5, 2))
+        # Reusing the same buffer for another node gives the right answer.
+        out2 = get_neighbors!(buf, g, 4)
+        @test Set(out2) == Set(_ref_neighbors(5, 4))
+    end
+
+    @testset "count_neighbors_by_state matches the generic oracle" begin
+        rng = MersenneTwister(42)
+        for n in (1, 2, 5, 20)
+            g = create_complete_graph(n)
+            # Random state assignment, including in-place mutation of the raw array
+            # (the path the models actually use).
+            states = node_states_raw(g)
+            for i in 1:n
+                states[i] = rand(rng, Int8(0):Int8(2))
+            end
+            for i in 1:n, s in (SUSCEPTIBLE, INFECTED, REMOVED)
+                @test count_neighbors_by_state(g, i, s) == _generic_count(g, i, s)
+            end
+        end
+    end
+
+    @testset "geometry: nodes on the unit circle, no cells" begin
+        n = 8
+        g = create_complete_graph(n)
+        @test has_layout(g) && layout_dim(g) == 2
+        @test !has_cells(g)                       # not a space-filling tiling
+        pos = node_positions(g)
+        @test size(pos) == (2, n)
+        for idx in 1:n
+            @test isapprox(hypot(pos[1, idx], pos[2, idx]), 1.0; atol = 1e-9)
+        end
+    end
+
+    @testset "memory: K_n is O(n), not O(n^2)" begin
+        # A materialized K_50000 would need ~2.5e9 neighbor entries (tens of GB).
+        # The implicit type must stay tiny — bounded by the n-length state vector.
+        g = create_complete_graph(50_000)
+        @test num_nodes(g) == 50_000
+        @test Base.summarysize(g) < 10 * 50_000   # ~1 byte/node of state + overhead
+    end
+
+    @testset "SIR runs on a complete graph and conserves nodes" begin
+        g = create_complete_graph(40)
+        p = SIRProcess(g, 3.0, 1.0)
+        reset!(p, [1]; rng_seed = 1)
+        steps = 0
+        while is_active(p) && steps < 5000
+            step!(p); steps += 1
+        end
+        counts = count_states(g)
+        @test counts[INFECTED] + counts[REMOVED] >= 1
+        @test counts[SUSCEPTIBLE] + counts[INFECTED] + counts[REMOVED] == num_nodes(g)
+    end
+end

--- a/test/test_erdos_renyi.jl
+++ b/test/test_erdos_renyi.jl
@@ -2,6 +2,7 @@ using Test
 using GraphEpimodels
 using Random
 using Statistics
+using Logging
 
 # Every directed neighbor relation is mirrored (undirected graph).
 function _er_is_symmetric(g)
@@ -95,6 +96,17 @@ _edge_count(g) = sum(length(get_neighbors(g, i)) for i in 1:num_nodes(g)) ÷ 2
         single = create_gnp(1, 0.5)
         @test num_nodes(single) == 1
         @test _edge_count(single) == 0
+    end
+
+    @testset "complete-graph fallback advisory" begin
+        # Small degenerate cases stay silent — the materialized K_n is cheap there.
+        @test_logs min_level = Logging.Warn create_gnp(20, 1.0)
+        @test_logs min_level = Logging.Warn create_gnm(20, 20 * 19 ÷ 2)
+
+        # Above the materialization threshold the helper warns (call it directly so
+        # no O(n²) graph is built), pointing users to CompleteGraph.
+        @test_logs (:warn, r"CompleteGraph") GraphEpimodels._warn_complete_fallback(
+            GraphEpimodels._COMPLETE_FALLBACK_WARN_N + 1)
     end
 
     @testset "interface forwarding" begin

--- a/test/test_structured_graphs.jl
+++ b/test/test_structured_graphs.jl
@@ -1,0 +1,133 @@
+using Test
+using GraphEpimodels
+using Random
+
+# Reference neighbor sets (the topology each implicit type must reproduce).
+_path_ref(n, i)  = filter(j -> 1 <= j <= n, [i - 1, i + 1])
+_cycle_ref(n, i) = [i == 1 ? n : i - 1, i == n ? 1 : i + 1]
+_star_ref(n, i)  = i == 1 ? collect(2:n) : [1]
+
+# Generic (interface-level) neighbor-by-state count, used as an oracle for the
+# per-type overrides. `count` returns 0 on an empty neighbor set.
+function _oracle_count(g, node_id, state)
+    states = node_states_raw(g)
+    target = state_to_int(state)
+    count(j -> states[j] == target, get_neighbors(g, node_id))
+end
+
+# Shared checks: topology matches the reference, plus the implicit-type invariants.
+function _check_topology(g, ref, n)
+    for i in 1:n
+        nb = get_neighbors(g, i)
+        @test Set(nb) == Set(ref(n, i))
+        @test i ∉ nb                              # no self-loop
+        @test length(nb) == length(unique(nb))    # no duplicates
+        @test get_node_degree(g, i) == length(ref(n, i))
+    end
+    for i in 1:n, j in get_neighbors(g, i)        # undirected: every edge mirrored
+        @test i in get_neighbors(g, j)
+    end
+end
+
+function _check_count_oracle(g, n)
+    rng = MersenneTwister(7)
+    states = node_states_raw(g)
+    for i in 1:n
+        states[i] = rand(rng, Int8(0):Int8(2))    # mutate the raw array in place
+    end
+    for i in 1:n, s in (SUSCEPTIBLE, INFECTED, REMOVED)
+        @test count_neighbors_by_state(g, i, s) == _oracle_count(g, i, s)
+    end
+end
+
+function _check_sir_conserves(g)
+    p = SIRProcess(g, 3.0, 1.0)
+    reset!(p, [1]; rng_seed = 1)
+    steps = 0
+    while is_active(p) && steps < 5000
+        step!(p); steps += 1
+    end
+    counts = count_states(g)
+    @test counts[INFECTED] + counts[REMOVED] >= 1
+    @test counts[SUSCEPTIBLE] + counts[INFECTED] + counts[REMOVED] == num_nodes(g)
+end
+
+@testset "Structured implicit graphs" begin
+    @testset "PathGraph" begin
+        g = create_path_graph(8)
+        @test g isa PathGraph && g isa AbstractImplicitGraph
+        @test !(g isa AbstractLatticeGraph)
+        @test num_nodes(g) == 8
+        @test_throws ArgumentError create_path_graph(0)
+
+        _check_topology(g, _path_ref, 8)
+        # Endpoints have degree 1, interior degree 2.
+        @test get_node_degree(g, 1) == 1
+        @test get_node_degree(g, 8) == 1
+        @test get_node_degree(g, 4) == 2
+
+        # Single-node path: valid, no neighbors.
+        @test isempty(get_neighbors(create_path_graph(1), 1))
+
+        _check_count_oracle(g, 8)
+
+        @test has_layout(g) && layout_dim(g) == 2 && !has_cells(g)
+        pos = node_positions(g)
+        @test size(pos) == (2, 8)
+        @test all(pos[2, :] .== 0.0)               # collinear on the x-axis
+        @test pos[1, :] == collect(1.0:8.0)
+
+        _check_sir_conserves(create_path_graph(30))
+    end
+
+    @testset "CycleGraph" begin
+        g = create_cycle_graph(9)
+        @test g isa CycleGraph && g isa AbstractImplicitGraph
+        @test !(g isa AbstractLatticeGraph)
+        @test num_nodes(g) == 9
+        @test_throws ArgumentError create_cycle_graph(2)   # needs >= 3
+
+        _check_topology(g, _cycle_ref, 9)
+        @test all(get_node_degree(g, i) == 2 for i in 1:9)
+        # Wraparound edge closes the ring.
+        @test Set(get_neighbors(g, 1)) == Set([9, 2])
+
+        _check_count_oracle(g, 9)
+
+        @test has_layout(g) && layout_dim(g) == 2 && !has_cells(g)
+        pos = node_positions(g)
+        @test size(pos) == (2, 9)
+        for idx in 1:9
+            @test isapprox(hypot(pos[1, idx], pos[2, idx]), 1.0; atol = 1e-9)
+        end
+
+        _check_sir_conserves(create_cycle_graph(30))
+    end
+
+    @testset "StarGraph" begin
+        n = 7
+        g = create_star_graph(n)
+        @test g isa StarGraph && g isa AbstractImplicitGraph
+        @test !(g isa AbstractLatticeGraph)
+        @test num_nodes(g) == n
+        @test_throws ArgumentError create_star_graph(1)    # needs >= 2
+
+        _check_topology(g, _star_ref, n)
+        @test get_node_degree(g, 1) == n - 1               # center
+        @test all(get_node_degree(g, i) == 1 for i in 2:n) # leaves
+        @test Set(get_neighbors(g, 1)) == Set(2:n)
+        @test get_neighbors(g, 3) == [1]
+
+        _check_count_oracle(g, n)
+
+        @test has_layout(g) && layout_dim(g) == 2 && !has_cells(g)
+        pos = node_positions(g)
+        @test size(pos) == (2, n)
+        @test pos[:, 1] == [0.0, 0.0]                      # center at the origin
+        for idx in 2:n
+            @test isapprox(hypot(pos[1, idx], pos[2, idx]), 1.0; atol = 1e-9)
+        end
+
+        _check_sir_conserves(create_star_graph(30))
+    end
+end


### PR DESCRIPTION
## Summary

Introduces `AbstractImplicitGraph` — an abstract category for graphs whose connectivity is a closed-form function of the node index (neighbors computed on demand, never stored). The existing `AbstractLatticeGraph` is reparented under it (non-breaking), and the four named structured-graph generators become dedicated implicit types: `CompleteGraph`, `PathGraph`, `CycleGraph`, `StarGraph`.

This puts structured graphs in the same *implicit* category as the lattices rather than the *materialized* `AdjacencyGraph` family — they no longer carry an adjacency list they would only be computing anyway.

### Type hierarchy

```
AbstractEpidemicGraph
├── AdjacencyGraph              (materialized: arbitrary graphs, Erdős–Rényi)
└── AbstractImplicitGraph       (edges = closed-form fn of index, not stored)
    ├── AbstractLatticeGraph    (Square / Triangular / Hexagonal)
    └── CompleteGraph / PathGraph / CycleGraph / StarGraph
```

## What each type gains

- **Memory.** Each stores only `n` + the `Int8` state vector. The headline win is `CompleteGraph`: `K_n` was O(n²) (and `@warn`ed past 10k nodes — a 50k-node complete graph would store 2.5 billion neighbor entries); it is now O(n), so `K_50000` is ~50 KB.
- **Allocation-free `count_neighbors_by_state`.** Small direct index checks for path/cycle; `global_count − self` for the complete graph and the star center; the single center check for a star leaf.
- **Deterministic layouts** for visualization (circle / line / radial) instead of a force-directed fallback.

## Compatibility

`create_complete_graph`, `create_path_graph`, `create_cycle_graph`, and `create_star_graph` now return the new types and move out of `adjacency.jl`. They had no other callers, so they are drop-in replacements.

## Design note

The original plan considered an O(1) `count_neighbors_by_state` for `CompleteGraph` via a maintained per-state histogram. This was deliberately **not** done: every model mutates state through direct raw-array writes (`states = node_states_raw(g); states[i] = …`), which would silently desync a cached histogram. The robust allocation-free O(n) scan is used instead. True O(1)-per-event complete-graph dynamics belong in a separate mean-field / compartmental path (counts as state, nodes anonymous), which does not fit the per-node graph interface and is out of scope here.

## Testing

- New `test/test_complete_graph.jl` and `test/test_structured_graphs.jl`: topology vs. reference, no self-loops, symmetry, degree, buffer-reusing `get_neighbors!`, `count_neighbors_by_state` vs. a generic oracle (including after in-place mutation), geometry, O(n) memory for `CompleteGraph`, and SIR node-conservation on each type.
- Full suite green: **1146 passing**, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
