### PR TITLE
Extend viz to all graph types, model-aware colors, gated render tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,8 +29,9 @@ ProgressMeter = "1"
 julia = "1.10"
 
 [extras]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Logging", "Test"]
+test = ["CairoMakie", "Logging", "Test"]

--- a/ext/GraphEpimodelsCairoMakieExt.jl
+++ b/ext/GraphEpimodelsCairoMakieExt.jl
@@ -148,29 +148,42 @@ function GraphEpimodels.visualize_state(viz::LatticeVisualizer, process::Abstrac
 end
 
 """
-Save a lattice visualization to file (format from the filename extension).
+Save a static visualization of a process to file (format from the filename extension).
+
+The visualizer is chosen by graph type via `visualizer_for`, so this works for
+lattices (square / triangular / hexagonal, drawn as dual-tiling cells) and for
+general / structured / random graphs (drawn as node-link diagrams) alike. The
+lattice-only options (`transparent_background`, `show_boundary`, `show_grid`) are
+ignored for node-link graphs.
 
 # Arguments
 - `process::AbstractEpidemicProcess`: Process to visualize
 - `filename::String`: Output path (`.png`, `.pdf`, `.svg`)
-- `color_scheme::Symbol`: Color scheme (default: `:zim`)
+- `color_scheme::Union{Symbol, Nothing}`: Color scheme; `nothing` (default) picks a
+  model-appropriate scheme via `default_color_scheme`
 - `figure_size::Tuple{Int, Int}`: Plot dimensions in pixels (default: (800, 800))
-- `transparent_background::Bool`: Transparent background + susceptible cells (default: false)
-- `show_boundary::Bool`: Outline the lattice boundary (default: false)
+- `transparent_background::Bool`: Transparent background + susceptible cells (lattices only; default: false)
+- `show_boundary::Bool`: Outline the lattice boundary (lattices only; default: false)
+- `show_grid::Bool`: Stroke cell outlines (cell lattices only; default: false)
 """
-function GraphEpimodels.save_lattice_plot(process::AbstractEpidemicProcess, filename::String;
-                                          color_scheme::Symbol = :zim,
+function GraphEpimodels.save_plot(process::AbstractEpidemicProcess, filename::String;
+                                          color_scheme::Union{Symbol, Nothing} = nothing,
                                           figure_size::Tuple{Int, Int} = (800, 800),
                                           transparent_background::Bool = false,
                                           show_boundary::Bool = false,
                                           show_grid::Bool = false)
-    viz = LatticeVisualizer(color_scheme = color_scheme,
-                            figure_size = figure_size,
-                            show_boundary = show_boundary,
-                            show_grid = show_grid)
-    fig = visualize_state(viz, process; transparent_background = transparent_background)
+    scheme = color_scheme === nothing ? default_color_scheme(process) : color_scheme
+    graph = get_graph(process)
+    viz = visualizer_for(graph; color_scheme = scheme, figure_size = figure_size)
+    if viz isa LatticeVisualizer
+        viz.show_boundary = show_boundary
+        viz.show_grid = show_grid
+        fig = visualize_state(viz, process; transparent_background = transparent_background)
+    else
+        fig = visualize_state(viz, process)
+    end
     save(filename, fig)
-    println("Lattice visualization saved to: $filename")
+    println("Visualization saved to: $filename")
     return fig
 end
 
@@ -181,8 +194,13 @@ end
 """
 Resolve node positions for a graph: attached coordinates if present, else a
 force-directed (spring) layout. Returns a `2 × n` `Matrix{Float64}`.
+
+Works for any `AbstractEpidemicGraph`: structured implicit graphs and lattices
+carry an intrinsic layout (`has_layout`), an `ErdosRenyiGraph` forwards the layout
+of its wrapped graph, and a bare `AdjacencyGraph` with no coordinates falls back
+to a spring layout.
 """
-function _resolve_positions(graph::AdjacencyGraph)::Matrix{Float64}
+function _resolve_positions(graph::AbstractEpidemicGraph)::Matrix{Float64}
     if has_layout(graph)
         pos = node_positions(graph)
         return size(pos, 1) == 2 ? pos : pos[1:2, :]   # drop z for 2D draw
@@ -201,10 +219,8 @@ function _resolve_positions(graph::AdjacencyGraph)::Matrix{Float64}
     return mat
 end
 
-_resolve_positions(graph::ErdosRenyiGraph)::Matrix{Float64} = _resolve_positions(graph.graph)
-
 """Draw a network frame into an existing axis (edges + colored node markers)."""
-function _draw_network!(ax, viz::NetworkVisualizer, graph::AdjacencyGraph,
+function _draw_network!(ax, viz::NetworkVisualizer, graph::AbstractEpidemicGraph,
                         states_raw::Vector{Int8};
                         positions::Union{Matrix{Float64}, Nothing} = nothing)
     pos = positions === nothing ? _resolve_positions(graph) : positions
@@ -225,11 +241,7 @@ function _draw_network!(ax, viz::NetworkVisualizer, graph::AdjacencyGraph,
     return ax
 end
 
-_draw_network!(ax, viz::NetworkVisualizer, graph::ErdosRenyiGraph, states_raw::Vector{Int8};
-               positions::Union{Matrix{Float64}, Nothing} = nothing) =
-    _draw_network!(ax, viz, graph.graph, states_raw; positions = positions)
-
-function GraphEpimodels.render_frame(viz::NetworkVisualizer, graph::AdjacencyGraph,
+function GraphEpimodels.render_frame(viz::NetworkVisualizer, graph::AbstractEpidemicGraph,
                                      states_raw::Vector{Int8}; title::String = "",
                                      positions::Union{Matrix{Float64}, Nothing} = nothing)
     fig = Figure(size = viz.figure_size)
@@ -239,10 +251,6 @@ function GraphEpimodels.render_frame(viz::NetworkVisualizer, graph::AdjacencyGra
     _draw_network!(ax, viz, graph, states_raw; positions = positions)
     return fig
 end
-
-GraphEpimodels.render_frame(viz::NetworkVisualizer, graph::ErdosRenyiGraph, states_raw::Vector{Int8};
-                            title::String = "", positions::Union{Matrix{Float64}, Nothing} = nothing) =
-    render_frame(viz, graph.graph, states_raw; title = title, positions = positions)
 
 function GraphEpimodels.visualize_state(viz::NetworkVisualizer, process::AbstractEpidemicProcess)
     validate_visualizer_compatibility(viz, process)
@@ -278,29 +286,41 @@ Render a recording to an animated GIF or MP4 (format from the filename extension
 Each frame is drawn with the same drawing core used by `visualize_state`, so
 frames look identical to static snapshots. The visualizer is chosen by graph type
 via `visualizer_for`, so this works for square / triangular / hexagonal lattices
-and for general (adjacency) graphs alike.
+and for general / structured / random graphs alike. Pass an explicit `visualizer`
+to override that choice — e.g. a `NetworkVisualizer` to draw a lattice as a
+node-link diagram.
 
 # Arguments
 - `rec::SimulationRecording`: The recording to animate
-- `color_scheme::Symbol`: Color scheme (default: `:sir`)
+- `color_scheme::Union{Symbol, Nothing}`: Color scheme; `nothing` (default) picks a
+  model-appropriate scheme from the recording's process name via `default_color_scheme`.
+  Ignored when an explicit `visualizer` is supplied (the visualizer carries its own).
 - `fps::Int`: Frames per second of the output (default: 15)
 - `filename::String`: Output path; `.gif` or `.mp4` (default: "simulation.gif")
 - `figure_size::Tuple{Int, Int}`: Frame size in pixels (default: (600, 600))
 - `show_boundary::Bool`: Outline the lattice boundary (lattices only; default: false)
 - `show_grid::Bool`: Stroke cell outlines (cell lattices only; default: false)
+- `visualizer::Union{AbstractVisualizer, Nothing}`: Override the auto-selected
+  visualizer (default: `nothing` → chosen by graph type).
 
 # Returns
 - `String`: The output filename.
 """
 function GraphEpimodels.animate_recording(rec::SimulationRecording;
-                                          color_scheme::Symbol = :sir,
+                                          color_scheme::Union{Symbol, Nothing} = nothing,
                                           fps::Int = 15,
                                           filename::String = "simulation.gif",
                                           figure_size::Tuple{Int, Int} = (600, 600),
                                           show_boundary::Bool = false,
-                                          show_grid::Bool = false)
+                                          show_grid::Bool = false,
+                                          visualizer::Union{AbstractVisualizer, Nothing} = nothing)
     graph = rec.graph
-    viz = visualizer_for(graph; color_scheme = color_scheme, figure_size = figure_size)
+    if visualizer === nothing
+        scheme = color_scheme === nothing ? default_color_scheme(rec.process_name) : color_scheme
+        viz = visualizer_for(graph; color_scheme = scheme, figure_size = figure_size)
+    else
+        viz = visualizer
+    end
     if viz isa LatticeVisualizer
         viz.show_boundary = show_boundary
         viz.show_grid = show_grid
@@ -351,12 +371,13 @@ function GraphEpimodels.animate_simulation(process::AbstractEpidemicProcess;
                                            max_time::Float64 = Inf,
                                            max_steps::Int = typemax(Int),
                                            stop_on_escape::Bool = false,
-                                           color_scheme::Symbol = :sir,
+                                           color_scheme::Union{Symbol, Nothing} = nothing,
                                            fps::Int = 15,
                                            filename::String = "simulation.gif",
                                            figure_size::Tuple{Int, Int} = (600, 600),
                                            show_boundary::Bool = false,
-                                           show_grid::Bool = false)::SimulationRecording
+                                           show_grid::Bool = false,
+                                           visualizer::Union{AbstractVisualizer, Nothing} = nothing)::SimulationRecording
     rec = record_simulation(process;
                             sampler = sampler,
                             max_time = max_time,
@@ -369,7 +390,8 @@ function GraphEpimodels.animate_simulation(process::AbstractEpidemicProcess;
                       filename = filename,
                       figure_size = figure_size,
                       show_boundary = show_boundary,
-                      show_grid = show_grid)
+                      show_grid = show_grid,
+                      visualizer = visualizer)
 
     return rec
 end

--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -181,13 +181,13 @@ include("visualization/visualization.jl")
 export AbstractVisualizer, StaticVisualizer, InteractiveVisualizer
 export visualize_state, supported_graph_types, can_visualize
 export visualizer_for, create_auto_visualizer, render_frame
-export COLOR_SCHEMES, get_state_color, available_color_schemes, print_color_schemes
-export extract_visualization_data, generate_visualization_title
+export COLOR_SCHEMES, available_color_schemes, print_color_schemes, default_color_scheme
+export generate_visualization_title
 export FIGURE_SIZES, get_figure_size
 
 # Lattice visualization (square / triangular / hexagonal)
 include("visualization/lattice_viz.jl")
-export LatticeVisualizer, save_lattice_plot
+export LatticeVisualizer, save_plot
 
 # Network visualization (general adjacency graphs)
 include("visualization/network_viz.jl")

--- a/src/visualization/lattice_viz.jl
+++ b/src/visualization/lattice_viz.jl
@@ -8,7 +8,7 @@ triangular→hexagon, hexagonal→triangle). Colors come from the shared
 `COLOR_SCHEMES` table; state 0/1/2 maps to susceptible/infected/removed.
 
 This file holds only the type and its backend-independent interface methods. The
-Makie rendering (`render_frame`, `visualize_state`, `save_lattice_plot`) lives in
+Makie rendering (`render_frame`, `visualize_state`, `save_plot`) lives in
 ext/GraphEpimodelsCairoMakieExt.jl and loads with `using CairoMakie`.
 """
 
@@ -32,7 +32,7 @@ mutable struct LatticeVisualizer <: StaticVisualizer
     show_grid::Bool
 
     function LatticeVisualizer(;
-                              color_scheme::Symbol = :zim,
+                              color_scheme::Symbol = :general,
                               show_boundary::Bool = false,
                               figure_size::Tuple{Int, Int} = (600, 600),
                               show_grid::Bool = false)

--- a/src/visualization/network_viz.jl
+++ b/src/visualization/network_viz.jl
@@ -33,7 +33,7 @@ mutable struct NetworkVisualizer <: StaticVisualizer
     edge_color
 
     function NetworkVisualizer(;
-                              color_scheme::Symbol = :sir,
+                              color_scheme::Symbol = :general,
                               figure_size::Tuple{Int, Int} = (700, 700),
                               node_size::Real = 12.0,
                               show_edges::Bool = true,
@@ -45,11 +45,13 @@ mutable struct NetworkVisualizer <: StaticVisualizer
 end
 
 function supported_graph_types(viz::NetworkVisualizer)::Vector{Type}
-    return [AdjacencyGraph, ErdosRenyiGraph]
+    return [AdjacencyGraph, ErdosRenyiGraph,
+            CompleteGraph, CycleGraph, PathGraph, StarGraph]
 end
 
-can_visualize(viz::NetworkVisualizer, graph::AdjacencyGraph)::Bool = true
-can_visualize(viz::NetworkVisualizer, graph::ErdosRenyiGraph)::Bool = true
+# A node-link visualizer can draw *any* graph: positions come from an attached
+# layout when present, or a force-directed fallback otherwise.
+can_visualize(viz::NetworkVisualizer, graph::AbstractEpidemicGraph)::Bool = true
 
 function get_visualization_settings(viz::NetworkVisualizer)::Dict{Symbol, Any}
     return Dict{Symbol, Any}(
@@ -60,13 +62,7 @@ function get_visualization_settings(viz::NetworkVisualizer)::Dict{Symbol, Any}
     )
 end
 
-# =============================================================================
-# Visualizer dispatch for Erdős–Rényi graphs
-# =============================================================================
-#
-# (Dispatch for AbstractLatticeGraph and AdjacencyGraph lives in
-# visualization.jl.) An Erdős–Rényi graph is a node-link graph, so it routes to
-# the NetworkVisualizer; the extension delegates its drawing to the wrapped
-# AdjacencyGraph.
-visualizer_for(graph::ErdosRenyiGraph; kwargs...)::AbstractVisualizer =
-    NetworkVisualizer(; kwargs...)
+# Visualizer dispatch lives in visualization.jl: the generic
+# `visualizer_for(::AbstractEpidemicGraph)` fallback routes every non-lattice graph
+# (general `AdjacencyGraph`, `ErdosRenyiGraph`, and the structured implicit graphs)
+# to the `NetworkVisualizer`.

--- a/src/visualization/visualization.jl
+++ b/src/visualization/visualization.jl
@@ -175,36 +175,55 @@ const COLOR_SCHEMES = Dict{Symbol, Dict{Symbol, Any}}(
         :boundary => :black,
         :background => :white,
         :name => "Chase-Escape (Prey=red, Predator=blue)"
+    ),
+
+    :maki_thompson => Dict(
+        :susceptible => :white,        # ignorant
+        :infected => :orange,          # spreader
+        :removed => :gray,             # stifler
+        :boundary => :black,
+        :background => :white,
+        :name => "Maki-Thompson (Spreader=orange, Stifler=gray)"
+    ),
+
+    # Neutral default for when the model is unknown / unspecified.
+    :general => Dict(
+        :susceptible => :lightgray,
+        :infected => :crimson,
+        :removed => :steelblue,
+        :boundary => :black,
+        :background => :white,
+        :name => "General (neutral default)"
     )
 )
 
 """
-Get color for a specific epidemic state from a color scheme.
+Pick the color scheme that best matches an epidemic model.
 
-# Arguments
-- `state::NodeState`: The epidemic state
-- `scheme::Symbol`: Color scheme name (default: :zim)
+Used by the rendering entry points so that omitting `color_scheme` yields a
+model-appropriate palette (the user can always override with an explicit scheme).
+Falls back to `:general` for unrecognized models.
 
-# Returns
-- Color value (type depends on plotting backend)
+Accepts either a process or a short process name (e.g. the `process_name` stored
+on a `SimulationRecording`: "SIR", "ZIM", …).
 """
-function get_state_color(state::NodeState, scheme::Symbol = :zim)
-    if scheme ∉ keys(COLOR_SCHEMES)
-        throw(ArgumentError("Unknown color scheme: $scheme. Available: $(keys(COLOR_SCHEMES))"))
-    end
-    
-    color_map = COLOR_SCHEMES[scheme]
-    
-    return if state == SUSCEPTIBLE
-        color_map[:susceptible]
-    elseif state == INFECTED  
-        color_map[:infected]
-    elseif state == REMOVED
-        color_map[:removed]
+function default_color_scheme(name::AbstractString)::Symbol
+    n = lowercase(name)
+    if n == "zim"
+        return :zim
+    elseif n == "sir"
+        return :sir
+    elseif n in ("chaseescape", "chase-escape", "chase_escape")
+        return :chaseescape
+    elseif n in ("makithompson", "maki-thompson", "maki_thompson")
+        return :maki_thompson
     else
-        color_map[:background]  # Fallback
+        return :general
     end
 end
+
+default_color_scheme(process::AbstractEpidemicProcess)::Symbol =
+    default_color_scheme(_process_name(process))
 
 """
 Get all available color scheme names.
@@ -326,7 +345,14 @@ end
 Return an appropriate visualizer for `graph`, selected by its type.
 
 - `AbstractLatticeGraph` (square / triangular / hexagonal) → `LatticeVisualizer`
-- `AdjacencyGraph` → `NetworkVisualizer`
+  (dual-tiling cells)
+- any other `AbstractEpidemicGraph` → `NetworkVisualizer` (node-link diagram)
+
+The lattice method is the more specific one, so lattices route to the
+`LatticeVisualizer`; everything else (general `AdjacencyGraph`, `ErdosRenyiGraph`,
+and the structured implicit graphs — complete / cycle / path / star) falls through
+to the node-link `NetworkVisualizer`, which can draw any graph (it has a
+spring-layout fallback when no coordinates are attached).
 
 Extra keyword arguments are forwarded to the visualizer constructor.
 """
@@ -334,44 +360,13 @@ function visualizer_for(graph::AbstractLatticeGraph; kwargs...)::AbstractVisuali
     return LatticeVisualizer(; kwargs...)
 end
 
-function visualizer_for(graph::AdjacencyGraph; kwargs...)::AbstractVisualizer
+function visualizer_for(graph::AbstractEpidemicGraph; kwargs...)::AbstractVisualizer
     return NetworkVisualizer(; kwargs...)
 end
 
 # =============================================================================
 # Utility Functions for Process Analysis
 # =============================================================================
-
-"""
-Extract visualization data from process state.
-
-Converts process state into a format suitable for visualization.
-This is a common operation that many visualizers need.
-
-# Arguments
-- `process::AbstractEpidemicProcess`: The process
-
-# Returns
-- `Dict{Symbol, Any}`: Visualization data including states, statistics, etc.
-"""
-function extract_visualization_data(process::AbstractEpidemicProcess)::Dict{Symbol, Any}
-    graph = get_graph(process)
-    states = node_states_raw(graph)  # Use raw states for performance
-    statistics = get_statistics(process)
-    
-    # Count states for summary info
-    state_counts = count_states(graph)
-    
-    return Dict{Symbol, Any}(
-        :node_states => states,
-        :state_counts => state_counts,
-        :statistics => statistics,
-        :graph => graph,
-        :num_nodes => num_nodes(graph),
-        :has_boundary => has_boundary(graph),
-        :boundary_nodes => get_boundary_nodes(graph)
-    )
-end
 
 """
 Generate title text for epidemic visualizations.
@@ -392,12 +387,7 @@ function generate_visualization_title(process::AbstractEpidemicProcess,
     base_title = if custom_title !== nothing
         custom_title
     else
-        process_name = if isa(process, ZIMProcess)
-            "ZIM"
-        else
-            string(typeof(process))
-        end
-        "Epidemic Simulation ($process_name)"
+        "Epidemic Simulation ($(_process_name(process)))"
     end
     
     info_parts = String[]
@@ -428,7 +418,7 @@ end
 # Makie-backed entry points (implemented in the CairoMakie extension)
 # =============================================================================
 #
-# `render_frame`, `save_lattice_plot`, `animate_recording`, and
+# `render_frame`, `save_plot`, `animate_recording`, and
 # `animate_simulation` are implemented in ext/GraphEpimodelsCairoMakieExt.jl,
 # which loads only when the user runs `using CairoMakie`. They are declared here
 # (as generic functions) so the package can export them and the extension can add
@@ -439,6 +429,6 @@ end
 const _MAKIE_HINT = "requires CairoMakie. Run `using CairoMakie` to enable plotting/animation."
 
 render_frame(args...; kwargs...)      = error("render_frame $_MAKIE_HINT")
-save_lattice_plot(args...; kwargs...) = error("save_lattice_plot $_MAKIE_HINT")
+save_plot(args...; kwargs...)         = error("save_plot $_MAKIE_HINT")
 animate_recording(args...; kwargs...) = error("animate_recording $_MAKIE_HINT")
 animate_simulation(args...; kwargs...) = error("animate_simulation $_MAKIE_HINT")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ using Random
     include("test_erdos_renyi.jl")
     include("test_complete_graph.jl")
     include("test_structured_graphs.jl")
+    include("test_visualization.jl")
 end

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -1,0 +1,136 @@
+using Test
+using GraphEpimodels
+using Random
+
+# -----------------------------------------------------------------------------
+# Graph fixtures, one per type. Lattices draw as dual-tiling cells; everything
+# else (structured implicit graphs, general adjacency, random ER) draws node-link.
+# -----------------------------------------------------------------------------
+lattice_graphs() = [
+    ("square",     create_square_lattice(6, 6)),
+    ("triangular", create_triangular_lattice(6, 6)),
+    ("hexagonal",  create_hexagonal_lattice(6, 6)),
+]
+
+network_graphs() = [
+    ("complete", create_complete_graph(8)),
+    ("cycle",    create_cycle_graph(10)),
+    ("path",     create_path_graph(10)),
+    ("star",     create_star_graph(7)),
+    ("er",       create_gnp(15, 0.3; rng = MersenneTwister(1))),
+    ("adjacency", create_graph_from_edges(4, [(1, 2), (2, 3), (3, 4)])),
+]
+
+# An SIR process on a graph, infected starting from node 1 (deterministic and
+# valid for every graph type, including those without a center node).
+sir_on(g) = create_sir_simulation(g, 0.6, 1.0; initial_infected = [1], rng_seed = 1)
+
+@testset "visualization" begin
+
+    # -------------------------------------------------------------------------
+    # Backend-independent: dispatch, compatibility, schemes, geometry. These run
+    # without CairoMakie and are cheap; they guard the integration wiring that is
+    # the substance of the visualization layer.
+    # -------------------------------------------------------------------------
+    @testset "visualizer_for dispatch" begin
+        for (_, g) in lattice_graphs()
+            @test visualizer_for(g) isa LatticeVisualizer
+        end
+        for (_, g) in network_graphs()
+            @test visualizer_for(g) isa NetworkVisualizer
+        end
+    end
+
+    @testset "can_visualize" begin
+        net = NetworkVisualizer()
+        lat = LatticeVisualizer()
+        # A node-link visualizer can draw any graph.
+        for (_, g) in vcat(lattice_graphs(), network_graphs())
+            @test can_visualize(net, g)
+        end
+        # A lattice visualizer handles lattices, not node-link graphs.
+        for (_, g) in lattice_graphs()
+            @test can_visualize(lat, g)
+        end
+        @test !can_visualize(lat, create_complete_graph(5))
+    end
+
+    @testset "color schemes" begin
+        @test :general in available_color_schemes()
+        @test :maki_thompson in available_color_schemes()
+        # Model-aware resolution by name.
+        @test default_color_scheme("SIR") == :sir
+        @test default_color_scheme("ZIM") == :zim
+        @test default_color_scheme("ChaseEscape") == :chaseescape
+        @test default_color_scheme("MakiThompson") == :maki_thompson
+        @test default_color_scheme("something-else") == :general
+        # Model-aware resolution by process.
+        @test default_color_scheme(sir_on(create_complete_graph(5))) == :sir
+        # Constructors default to the neutral scheme.
+        @test NetworkVisualizer().color_scheme == :general
+        @test LatticeVisualizer().color_scheme == :general
+    end
+
+    @testset "node_positions shape" begin
+        # Every graph type that reports a layout returns a 2 × N matrix.
+        for (_, g) in vcat(lattice_graphs(), network_graphs())
+            has_layout(g) || continue
+            @test size(node_positions(g)) == (2, num_nodes(g))
+        end
+    end
+
+    # -------------------------------------------------------------------------
+    # Rendering smoke test (needs CairoMakie). Loading CairoMakie (~10 s) plus
+    # first-call compilation of the Makie draw paths dominate the suite, so this
+    # tier is OFF by default and runs only when GRAPHEPIMODELS_VIZ_RENDER is set
+    # (or under CI). The cases below cover every distinct draw path exactly once:
+    #   - square     -> lattice `image!` fast path
+    #   - triangular -> lattice `poly!` dual-cell path (shared by hexagonal)
+    #   - complete   -> node-link with an intrinsic layout
+    #   - adjacency  -> node-link with the spring-layout fallback (no coords)
+    # plus the two animation record paths (lattice cells and node-link) and the
+    # visualizer override.
+    # -------------------------------------------------------------------------
+    run_render = haskey(ENV, "GRAPHEPIMODELS_VIZ_RENDER") || get(ENV, "CI", "false") == "true"
+
+    if !run_render
+        @info "Skipping CairoMakie rendering tests (set GRAPHEPIMODELS_VIZ_RENDER=1 to run them)"
+    else
+        using CairoMakie
+        @testset "rendering (CairoMakie)" begin
+            dir = mktempdir()
+            render_cases = [("square",     create_square_lattice(6, 6)),
+                            ("triangular", create_triangular_lattice(6, 6)),
+                            ("complete",   create_complete_graph(8)),
+                            ("adjacency",  create_graph_from_edges(4, [(1, 2), (2, 3), (3, 4)]))]
+
+            @testset "render_frame + save: $name" for (name, g) in render_cases
+                proc = sir_on(g)
+                fig = render_frame(visualizer_for(g), g, node_states_raw(g))
+                @test fig isa Figure
+                file = joinpath(dir, "static_$name.png")
+                save_plot(proc, file)
+                @test isfile(file) && filesize(file) > 0
+            end
+
+            @testset "animate_simulation (lattice cells path)" begin
+                file = joinpath(dir, "anim_square.gif")
+                rec = animate_simulation(sir_on(create_square_lattice(6, 6));
+                                         sampler = EveryStep(), max_steps = 20, filename = file)
+                @test rec isa SimulationRecording
+                @test num_frames(rec) >= 2
+                @test isfile(file) && filesize(file) > 0
+            end
+
+            # Forcing a NetworkVisualizer on a lattice covers both the override
+            # feature and the node-link animation record path in one go.
+            @testset "lattice as node-link via visualizer override" begin
+                file = joinpath(dir, "lattice_nodelink.gif")
+                animate_simulation(sir_on(create_square_lattice(6, 6));
+                                   sampler = EveryStep(), max_steps = 20,
+                                   filename = file, visualizer = NetworkVisualizer())
+                @test isfile(file) && filesize(file) > 0
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- **Universal NetworkVisualizer fallback** — `CompleteGraph`, `CycleGraph`, `PathGraph`, and `StarGraph` are now fully renderable. A generic `visualizer_for(::AbstractEpidemicGraph)` overload routes them to `NetworkVisualizer`; lattice graphs still resolve to `LatticeVisualizer` via the more-specific dispatch. Rendering internals (`_resolve_positions`, `_draw_network!`, `render_frame`) are broadened from `AdjacencyGraph` to `AbstractEpidemicGraph`; graphs without intrinsic positions fall back to spring layout.
- **Visualizer override in animators** — `animate_recording` and `animate_simulation` gain an optional `visualizer` kwarg so callers can force a node-link view for lattice graphs (e.g. `animate_simulation(proc; visualizer=NetworkVisualizer())`).
- **Model-aware color schemes** — new `:general` (neutral) and `:maki_thompson` schemes added. New `default_color_scheme(process/name)` resolver picks the model-specific scheme automatically; an explicit `color_scheme` kwarg still takes precedence. Both `LatticeVisualizer` and `NetworkVisualizer` default to `:general` instead of hard-coded `:sir`/`:zim`.
- **`save_lattice_plot` → `save_plot`** — renamed since it now routes via `visualizer_for` and handles all graph types, not just lattices.
- **Title consistency** — `generate_visualization_title` now uses `_process_name` for all models instead of special-casing `ZIMProcess`.
- **Dead-code removal** — `get_state_color` and `extract_visualization_data` (unused migration-era helpers) removed from both the module and exports.
- **Visualization tests** — new `test/test_visualization.jl` with two tiers: backend-independent (dispatch, color schemes, `node_positions` shape — always runs, ~0s overhead) and rendering (gated on `GRAPHEPIMODELS_VIZ_RENDER=1` or `CI=true` to keep routine `Pkg.test` fast at ~19s vs ~56s with rendering always-on).

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` — all 1200+ tests pass, routine run stays ~19s.
- [x] `GRAPHEPIMODELS_VIZ_RENDER=1 julia --project -e 'using Pkg; Pkg.test()'` — rendering tier runs (square/triangular lattice, complete graph, adjacency spring fallback, animations, visualizer override).
- [x] Smoke: `visualizer_for(create_complete_graph(8))` returns `NetworkVisualizer` (was `MethodError`).
- [x] Smoke: `save_plot(sim, "out.png")` works for both a lattice sim and a structured-graph sim.
- [x] Smoke: `animate_simulation(lat_sim; visualizer=NetworkVisualizer(), filename="out.gif")` produces a node-link animation for a square lattice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)