### PR TITLE
Rename create_X_simulation → create_X_process; extract shared init-node helper

### DIFF
--- a/examples/make_animations.jl
+++ b/examples/make_animations.jl
@@ -65,23 +65,23 @@ patch = center_patch(L, 2)   # 5x5 = 25-node center seed (robust takeoff)
 
 # 1. SIR — infection (red) sweeps out leaving recovered (gray) behind.
 animate_model("SIR",
-    () -> create_sir_simulation(L, L, 3.0, 1.0; initial_infected=patch, rng_seed=SEED);
+    () -> create_sir_process(L, L, 3.0, 1.0; initial_infected=patch, rng_seed=SEED);
     color_scheme = :sir, filename = "sir.gif")
 
 # 2. ZIM (Zombie Infection Model) — zombies (green) spread, killed (red) behind.
 animate_model("ZIM",
-    () -> create_zim_simulation(L, L, 3.0, 1.0; initial_infected=patch, rng_seed=SEED);
+    () -> create_zim_process(L, L, 3.0, 1.0; initial_infected=patch, rng_seed=SEED);
     color_scheme = :zim, filename = "zim.gif")
 
 # 3. Maki-Thompson rumor spreading — spreaders (orange) advance, stiflers (purple) behind.
 animate_model("Maki-Thompson",
-    () -> create_maki_thompson_simulation(L, L, 3.0, 1.0; initial_infected=patch, rng_seed=SEED);
+    () -> create_maki_thompson_process(L, L, 3.0, 1.0; initial_infected=patch, rng_seed=SEED);
     color_scheme = :medical, filename = "maki_thompson.gif")
 
 # 4. Chase-escape (predator-prey) — prey (red) escapes outward, predator (blue) chases from within.
 #    Needs lambda > mu so prey can outrun the predator; ghost seeds the chase from the center patch.
 animate_model("Chase-escape",
-    () -> create_chase_escape_simulation(L, L, 3.0, 1.0; ghost=true, initial_red=patch, rng_seed=SEED);
+    () -> create_chase_escape_process(L, L, 3.0, 1.0; ghost=true, initial_red=patch, rng_seed=SEED);
     color_scheme = :chaseescape, filename = "chase_escape.gif")
 
 # =============================================================================

--- a/examples/transparent_demo.jl
+++ b/examples/transparent_demo.jl
@@ -50,7 +50,7 @@ end
 
 println("Square lattice ...")
 
-sq = create_sir_simulation(40, 40, 4.0, 1.0; rng_seed = SEED)
+sq = create_sir_process(40, 40, 4.0, 1.0; rng_seed = SEED)
 run_to_mid(sq)
 
 viz_sq = LatticeVisualizer(color_scheme = :sir, figure_size = (500, 500), show_grid = true)

--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -21,7 +21,7 @@ For parallel survival probability analysis, start Julia with multiple threads:
 using GraphEpimodels
 
 # Create ZIM simulation on 100×100 lattice
-zim = create_zim_simulation(100, 100, 2.0)  # λ = 2.0
+zim = create_zim_process(100, 100, 2.0)  # λ = 2.0
 
 # Run single simulation  
 results = run_simulation(zim; max_time=50.0)
@@ -126,25 +126,25 @@ export run_simulation
 include("models/zim.jl")
 export ZIMProcess
 export has_escaped, get_zim_statistics
-export create_zim_simulation
+export create_zim_process
 
 # SIR Model
 include("models/sir.jl")
 export SIRProcess
 export get_sir_statistics
-export create_sir_simulation
+export create_sir_process
 
 # Maki-Thompson Rumor Spreading Model
 include("models/maki_thompson.jl")
 export MakiThompsonProcess
 export get_maki_thompson_statistics
-export create_maki_thompson_simulation
+export create_maki_thompson_process
 
 # Chase-Escape Model
 include("models/chasescape.jl")
 export ChaseEscapeProcess
 export get_chase_escape_statistics
-export create_chase_escape_simulation
+export create_chase_escape_process
 
 # =============================================================================
 # Utilities
@@ -221,7 +221,7 @@ function print_info()
     println()
     println("Quick start:")
     println("  julia> using GraphEpimodels")
-    println("  julia> zim = create_zim_simulation(100, 100, 2.0)")
+    println("  julia> zim = create_zim_process(100, 100, 2.0)")
     println("  julia> results = run_simulation(zim)")
     println("  julia> println(\"Escaped: \", has_escaped(zim))")
     println()

--- a/src/analysis/survival_analysis.jl
+++ b/src/analysis/survival_analysis.jl
@@ -84,7 +84,7 @@ Estimate survival probability using threading for maximum performance with minim
 # Examples
 ```julia
 # Simple ZIM analysis
-factory = () -> create_zim_simulation(100, 100, 2.0)
+factory = () -> create_zim_process(100, 100, 2.0)
 result = estimate_survival_probability(factory, [center_node])
 
 # With detailed data collection
@@ -92,7 +92,7 @@ result = estimate_survival_probability(factory, [center_node]; mode=DETAILED)
 
 # Custom factory with parameters
 λ, width, height = 2.5, 200, 200
-factory = () -> create_zim_simulation(width, height, λ; rng_seed=rand(UInt))
+factory = () -> create_zim_process(width, height, λ; rng_seed=rand(UInt))
 result = estimate_survival_probability(factory, [center_node]; num_simulations=10000)
 ```
 """
@@ -332,7 +332,7 @@ When CSV persistence is enabled, the function automatically continues from previ
 # Basic parameter sweep (all parameters use seeds 1-100)
 sweep = run_parameter_sweep(
     [1.5, 2.0, 2.5],
-    λ -> (() -> create_zim_simulation(100, 100, λ)),
+    λ -> (() -> create_zim_process(100, 100, λ)),
     [center_node];
     num_simulations = 100
 )
@@ -340,7 +340,7 @@ sweep = run_parameter_sweep(
 # With CSV persistence - automatically continues from previous runs
 sweep = run_parameter_sweep(
     [1.0:0.1:3.0...],
-    λ -> (() -> create_zim_simulation(200, 200, λ)),
+    λ -> (() -> create_zim_process(200, 200, λ)),
     [center_node];
     save_to = "zim_study.csv",
     num_simulations = 1000
@@ -457,12 +457,12 @@ function run_zim_lattice_survival_analysis(
 )::Dict{Symbol, Any}
     
     # Create factory generator for ZIM processes
-    factory_generator = λ -> (() -> create_zim_simulation(width, height, λ, mu))
+    factory_generator = λ -> (() -> create_zim_process(width, height, λ, mu))
     
     # Determine initial infected nodes
     if initial_location == :center
         # Create dummy process to get center node
-        dummy_process = create_zim_simulation(width, height, lambda_values[1], mu)
+        dummy_process = create_zim_process(width, height, lambda_values[1], mu)
         initial_infected = [get_center_node(get_graph(dummy_process))]
     elseif initial_location == :corner
         initial_infected = [1]  # Corner node

--- a/src/core/persistence.jl
+++ b/src/core/persistence.jl
@@ -33,7 +33,7 @@ JSON serialization.
 
 # Example
 ```julia
-zim = create_zim_simulation(100, 100, 2.0, 1.0)
+zim = create_zim_process(100, 100, 2.0, 1.0)
 info = extract_process_info(zim)
 # Returns: Dict("process_type" => "ZIMProcess", "lambda" => 2.0, ...)
 ```

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -77,6 +77,29 @@ function set_global_seed!(seed::Int)
 end
 
 # =============================================================================
+# Initial Node Resolution
+# =============================================================================
+
+"""
+Resolve an `initial_nodes` spec into a concrete `Vector{Int}`.
+
+Accepts `:center` (graph center or midpoint fallback), `:random` (one random
+node), or an explicit `Vector{Int}` that is returned as-is.
+"""
+function resolve_initial_nodes(graph::AbstractEpidemicGraph,
+                               spec::Union{Symbol, Vector{Int}},
+                               rng::AbstractRNG)::Vector{Int}
+    if spec == :center
+        hasmethod(get_center_node, (typeof(graph),)) ?
+            [get_center_node(graph)] : [num_nodes(graph) ÷ 2]
+    elseif spec == :random
+        [rand(rng, 1:num_nodes(graph))]
+    else
+        spec
+    end
+end
+
+# =============================================================================
 # Performance Monitoring
 # =============================================================================
 

--- a/src/models/chasescape.jl
+++ b/src/models/chasescape.jl
@@ -351,49 +351,36 @@ Create a complete Chase-escape simulation setup.
 # Example
 ```julia
 julia> lattice = create_square_lattice(100, 100, :absorbing)
-julia> ce = create_chase_escape_simulation(lattice, 2.0)
+julia> ce = create_chase_escape_process(lattice, 2.0)
 julia> results = run_simulation(ce)
 ```
 """
-function create_chase_escape_simulation(graph::AbstractEpidemicGraph,
-                                        λ::Float64, μ::Float64 = 1.0;
-                                        ghost::Bool = true,
-                                        initial_red::Union{Symbol, Vector{Int}} = :center,
-                                        initial_blue::Vector{Int} = Int[],
-                                        rng_seed::Union{Int, Nothing} = nothing)
+function create_chase_escape_process(graph::AbstractEpidemicGraph,
+                                     λ::Float64, μ::Float64 = 1.0;
+                                     ghost::Bool = true,
+                                     initial_red::Union{Symbol, Vector{Int}} = :center,
+                                     initial_blue::Vector{Int} = Int[],
+                                     rng_seed::Union{Int, Nothing} = nothing)
     rng     = create_rng(rng_seed)
     process = ChaseEscapeProcess(graph, λ, μ; ghost = ghost, rng = rng)
-
-    red_nodes = if initial_red == :center
-        if hasmethod(get_center_node, (typeof(graph),))
-            [get_center_node(graph)]
-        else
-            [num_nodes(graph) ÷ 2]
-        end
-    elseif initial_red == :random
-        [rand(rng, 1:num_nodes(graph))]
-    else
-        initial_red
-    end
-
-    reset!(process, red_nodes; initial_blue = initial_blue)
+    reset!(process, resolve_initial_nodes(graph, initial_red, rng); initial_blue = initial_blue)
     return process
 end
 
 """
-Convenience function for creating a Chase-escape simulation on a square lattice.
+Convenience overload for creating a Chase-Escape process on a square lattice.
 """
-function create_chase_escape_simulation(width::Int, height::Int,
-                                        λ::Float64, μ::Float64 = 1.0;
-                                        ghost::Bool = true,
-                                        boundary::Symbol = :absorbing,
-                                        initial_red::Union{Symbol, Vector{Int}} = :center,
-                                        initial_blue::Vector{Int} = Int[],
-                                        rng_seed::Union{Int, Nothing} = nothing)
+function create_chase_escape_process(width::Int, height::Int,
+                                     λ::Float64, μ::Float64 = 1.0;
+                                     ghost::Bool = true,
+                                     boundary::Symbol = :absorbing,
+                                     initial_red::Union{Symbol, Vector{Int}} = :center,
+                                     initial_blue::Vector{Int} = Int[],
+                                     rng_seed::Union{Int, Nothing} = nothing)
     lattice = create_square_lattice(width, height, boundary)
-    return create_chase_escape_simulation(lattice, λ, μ;
-                                          ghost        = ghost,
-                                          initial_red  = initial_red,
-                                          initial_blue = initial_blue,
-                                          rng_seed     = rng_seed)
+    return create_chase_escape_process(lattice, λ, μ;
+                                       ghost        = ghost,
+                                       initial_red  = initial_red,
+                                       initial_blue = initial_blue,
+                                       rng_seed     = rng_seed)
 end

--- a/src/models/epiprocess.jl
+++ b/src/models/epiprocess.jl
@@ -244,7 +244,7 @@ Run complete simulation until stopping condition.
 
 # Example
 ```julia
-julia> zim = create_zim_simulation(100, 100, 2.0)
+julia> zim = create_zim_process(100, 100, 2.0)
 julia> results = run_simulation(zim; max_time=50.0)
 julia> println("Final infected: ", results[:infected])
 ```

--- a/src/models/maki_thompson.jl
+++ b/src/models/maki_thompson.jl
@@ -336,46 +336,33 @@ Create a complete Maki-Thompson simulation setup.
 # Example
 ```julia
 julia> lattice = create_square_lattice(100, 100, :absorbing)
-julia> mt = create_maki_thompson_simulation(lattice, 1.0)
+julia> mt = create_maki_thompson_process(lattice, 1.0)
 julia> results = run_simulation(mt)
 ```
 """
-function create_maki_thompson_simulation(graph::AbstractEpidemicGraph,
-                                          α::Float64, β::Float64 = 1.0;
-                                          stifler_contact::Bool = true,
-                                          initial_infected::Union{Symbol, Vector{Int}} = :center,
-                                          rng_seed::Union{Int, Nothing} = nothing)
+function create_maki_thompson_process(graph::AbstractEpidemicGraph,
+                                      α::Float64, β::Float64 = 1.0;
+                                      stifler_contact::Bool = true,
+                                      initial_infected::Union{Symbol, Vector{Int}} = :center,
+                                      rng_seed::Union{Int, Nothing} = nothing)
     rng     = create_rng(rng_seed)
     process = MakiThompsonProcess(graph, α, β, stifler_contact; rng = rng)
-
-    infected_nodes = if initial_infected == :center
-        if hasmethod(get_center_node, (typeof(graph),))
-            [get_center_node(graph)]
-        else
-            [num_nodes(graph) ÷ 2]
-        end
-    elseif initial_infected == :random
-        [rand(rng, 1:num_nodes(graph))]
-    else
-        initial_infected
-    end
-
-    reset!(process, infected_nodes)
+    reset!(process, resolve_initial_nodes(graph, initial_infected, rng))
     return process
 end
 
 """
-Convenience function for creating a Maki-Thompson simulation on a square lattice.
+Convenience overload for creating a Maki-Thompson process on a square lattice.
 """
-function create_maki_thompson_simulation(width::Int, height::Int,
-                                          α::Float64, β::Float64 = 1.0;
-                                          stifler_contact::Bool = true,
-                                          boundary::Symbol = :absorbing,
-                                          initial_infected::Union{Symbol, Vector{Int}} = :center,
-                                          rng_seed::Union{Int, Nothing} = nothing)
+function create_maki_thompson_process(width::Int, height::Int,
+                                      α::Float64, β::Float64 = 1.0;
+                                      stifler_contact::Bool = true,
+                                      boundary::Symbol = :absorbing,
+                                      initial_infected::Union{Symbol, Vector{Int}} = :center,
+                                      rng_seed::Union{Int, Nothing} = nothing)
     lattice = create_square_lattice(width, height, boundary)
-    return create_maki_thompson_simulation(lattice, α, β;
-                                           stifler_contact   = stifler_contact,
-                                           initial_infected  = initial_infected,
-                                           rng_seed          = rng_seed)
+    return create_maki_thompson_process(lattice, α, β;
+                                        stifler_contact  = stifler_contact,
+                                        initial_infected = initial_infected,
+                                        rng_seed         = rng_seed)
 end

--- a/src/models/sir.jl
+++ b/src/models/sir.jl
@@ -273,7 +273,7 @@ end
 # =============================================================================
 
 """
-Create a complete SIR simulation setup.
+Create a configured SIR process ready to run.
 
 # Arguments
 - `graph::AbstractEpidemicGraph`: The graph to simulate on
@@ -288,39 +288,26 @@ Create a complete SIR simulation setup.
 # Example
 ```julia
 julia> lattice = create_square_lattice(100, 100, :absorbing)
-julia> sir = create_sir_simulation(lattice, 0.5)
+julia> sir = create_sir_process(lattice, 0.5)
 julia> results = run_simulation(sir; max_time=100.0)
 ```
 """
-function create_sir_simulation(graph::AbstractEpidemicGraph, β::Float64, γ::Float64 = 1.0;
-                               initial_infected::Union{Symbol, Vector{Int}} = :center,
-                               rng_seed::Union{Int, Nothing} = nothing)
+function create_sir_process(graph::AbstractEpidemicGraph, β::Float64, γ::Float64 = 1.0;
+                            initial_infected::Union{Symbol, Vector{Int}} = :center,
+                            rng_seed::Union{Int, Nothing} = nothing)
     rng = create_rng(rng_seed)
     process = SIRProcess(graph, β, γ; rng=rng)
-
-    infected_nodes = if initial_infected == :center
-        if isdefined(graph, :get_center_node) || hasmethod(get_center_node, (typeof(graph),))
-            [get_center_node(graph)]
-        else
-            [num_nodes(graph) ÷ 2]
-        end
-    elseif initial_infected == :random
-        [rand(rng, 1:num_nodes(graph))]
-    else
-        initial_infected
-    end
-
-    reset!(process, infected_nodes)
+    reset!(process, resolve_initial_nodes(graph, initial_infected, rng))
     return process
 end
 
 """
-Convenience function for creating SIR on square lattices.
+Convenience overload for creating an SIR process on a square lattice.
 """
-function create_sir_simulation(width::Int, height::Int, β::Float64, γ::Float64 = 1.0;
-                               boundary::Symbol = :absorbing,
-                               initial_infected::Union{Symbol, Vector{Int}} = :center,
-                               rng_seed::Union{Int, Nothing} = nothing)
+function create_sir_process(width::Int, height::Int, β::Float64, γ::Float64 = 1.0;
+                            boundary::Symbol = :absorbing,
+                            initial_infected::Union{Symbol, Vector{Int}} = :center,
+                            rng_seed::Union{Int, Nothing} = nothing)
     lattice = create_square_lattice(width, height, boundary)
-    return create_sir_simulation(lattice, β, γ; initial_infected=initial_infected, rng_seed=rng_seed)
+    return create_sir_process(lattice, β, γ; initial_infected=initial_infected, rng_seed=rng_seed)
 end

--- a/src/models/zim.jl
+++ b/src/models/zim.jl
@@ -347,47 +347,26 @@ Create a complete ZIM simulation setup.
 # Example
 ```julia  
 julia> lattice = create_square_lattice(100, 100, :absorbing)
-julia> zim = create_zim_simulation(lattice, 2.0)
+julia> zim = create_zim_process(lattice, 2.0)
 julia> results = run_simulation(zim; max_time=100.0, stop_on_escape=true)
 ```
 """
-function create_zim_simulation(graph::AbstractEpidemicGraph, λ::Float64, μ::Float64 = 1.0;
-                              initial_infected::Union{Symbol, Vector{Int}} = :center,
-                              rng_seed::Union{Int, Nothing} = nothing)
-    
-    # Create RNG using utils.jl function
+function create_zim_process(graph::AbstractEpidemicGraph, λ::Float64, μ::Float64 = 1.0;
+                           initial_infected::Union{Symbol, Vector{Int}} = :center,
+                           rng_seed::Union{Int, Nothing} = nothing)
     rng = create_rng(rng_seed)
-    
-    # Create process
     process = ZIMProcess(graph, λ, μ; rng=rng)
-    
-    # Determine initial infected nodes
-    infected_nodes = if initial_infected == :center
-        if isdefined(graph, :get_center_node) || hasmethod(get_center_node, (typeof(graph),))
-            [get_center_node(graph)]
-        else
-            [num_nodes(graph) ÷ 2]  # Fallback for general graphs
-        end
-    elseif initial_infected == :random
-        [rand(rng, 1:num_nodes(graph))]
-    else
-        initial_infected
-    end
-    
-    # Initialize the process
-    reset!(process, infected_nodes)
-    
+    reset!(process, resolve_initial_nodes(graph, initial_infected, rng))
     return process
 end
 
 """
-Convenience function for creating ZIM on square lattices (backward compatibility).
+Convenience overload for creating a ZIM process on a square lattice.
 """
-function create_zim_simulation(width::Int, height::Int, λ::Float64, μ::Float64 = 1.0;
-                              boundary::Symbol = :absorbing,
-                              initial_infected::Union{Symbol, Vector{Int}} = :center,
-                              rng_seed::Union{Int, Nothing} = nothing)
-    
+function create_zim_process(width::Int, height::Int, λ::Float64, μ::Float64 = 1.0;
+                           boundary::Symbol = :absorbing,
+                           initial_infected::Union{Symbol, Vector{Int}} = :center,
+                           rng_seed::Union{Int, Nothing} = nothing)
     lattice = create_square_lattice(width, height, boundary)
-    return create_zim_simulation(lattice, λ, μ; initial_infected=initial_infected, rng_seed=rng_seed)
+    return create_zim_process(lattice, λ, μ; initial_infected=initial_infected, rng_seed=rng_seed)
 end

--- a/src/visualization/animation.jl
+++ b/src/visualization/animation.jl
@@ -24,11 +24,11 @@ Two sampling regimes (see `FrameSampler`):
 using GraphEpimodels, CairoMakie   # CairoMakie enables animate_*
 
 # Small lattice — animate every transition
-sir = create_sir_simulation(30, 30, 0.6, 1.0; initial_infected=:center, rng_seed=1)
+sir = create_sir_process(30, 30, 0.6, 1.0; initial_infected=:center, rng_seed=1)
 animate_simulation(sir; sampler=EveryStep(), color_scheme=:sir, filename="sir_small.gif")
 
 # Large lattice — equal-time sampling for faithful playback
-big = create_sir_simulation(200, 200, 0.6, 1.0; initial_infected=:center, rng_seed=1)
+big = create_sir_process(200, 200, 0.6, 1.0; initial_infected=:center, rng_seed=1)
 animate_simulation(big; sampler=TimeInterval(0.5), max_time=40.0, filename="sir_large.mp4")
 ```
 """

--- a/test/test_chasescape.jl
+++ b/test/test_chasescape.jl
@@ -21,14 +21,14 @@
         @test_throws ArgumentError ChaseEscapeProcess(g, 0.0, 1.0)
         @test_throws ArgumentError ChaseEscapeProcess(g, 1.0, -1.0)
         @test_throws ArgumentError ChaseEscapeProcess(g, 1.0, 0.0)
-        @test_throws ArgumentError create_chase_escape_simulation(g, 0.0)
+        @test_throws ArgumentError create_chase_escape_process(g, 0.0)
 
         # Red/blue seed sets must be disjoint.
-        @test_throws ArgumentError create_chase_escape_simulation(
+        @test_throws ArgumentError create_chase_escape_process(
             g, 1.0, 1.0; ghost = false, initial_red = [1], initial_blue = [1])
 
         # Out-of-range blue seed.
-        @test_throws ArgumentError create_chase_escape_simulation(
+        @test_throws ArgumentError create_chase_escape_process(
             g, 1.0, 1.0; ghost = false, initial_red = [1], initial_blue = [99])
     end
 
@@ -37,7 +37,7 @@
 
         # Single red seed, ghost on: the ghost makes the seed catchable but is
         # never placed in the graph (so REMOVED count stays 0).
-        p = create_chase_escape_simulation(g, 2.0, 1.0; ghost = true, initial_red = [1])
+        p = create_chase_escape_process(g, 2.0, 1.0; ghost = true, initial_red = [1])
         st = get_chase_escape_statistics(p)
         @test st[:infected] == 1
         @test st[:removed]  == 0          # ghost is not a real node
@@ -47,7 +47,7 @@
         @test is_active(p)
 
         # ghost = false with an explicit blue seed adjacent to the red seed.
-        p2 = create_chase_escape_simulation(
+        p2 = create_chase_escape_process(
             g, 2.0, 1.0; ghost = false, initial_red = [2], initial_blue = [1])
         st2 = get_chase_escape_statistics(p2)
         @test st2[:infected] == 1
@@ -56,7 +56,7 @@
         @test is_active(p2)
 
         # ghost = false with no blue seeds warns (degenerate pure-growth regime).
-        @test_logs (:warn,) match_mode=:any create_chase_escape_simulation(
+        @test_logs (:warn,) match_mode=:any create_chase_escape_process(
             g, 2.0, 1.0; ghost = false, initial_red = [1])
     end
 
@@ -66,7 +66,7 @@
         #                    node 1 has no white neighbour (2 is red)  => 0
         #   catch_boundary : nodes 1 and 2 each carry a ghost (+1)     => 2
         g = create_path_graph(5)
-        p = create_chase_escape_simulation(g, 1.5, 1.0; ghost = true, initial_red = [1, 2])
+        p = create_chase_escape_process(g, 1.5, 1.0; ghost = true, initial_red = [1, 2])
         st = get_chase_escape_statistics(p)
         @test st[:spread_boundary] == 1
         @test st[:catch_boundary]  == 2
@@ -76,7 +76,7 @@
     @testset "Spread event bookkeeping" begin
         # [R, W, W, W, W]; spread from node 1 must convert node 2.
         g = create_path_graph(5)
-        p = create_chase_escape_simulation(g, 1.0, 1.0; ghost = true, initial_red = [1])
+        p = create_chase_escape_process(g, 1.0, 1.0; ghost = true, initial_red = [1])
         GraphEpimodels._ce_spread!(p, 1)
 
         @test get_node_state(g, 2) == INFECTED
@@ -94,7 +94,7 @@
         # [R, R, W, W, W]; catching node 1 turns it blue and increments the catch
         # weight of its red neighbour (node 2).
         g = create_path_graph(5)
-        p = create_chase_escape_simulation(g, 1.0, 1.0; ghost = true, initial_red = [1, 2])
+        p = create_chase_escape_process(g, 1.0, 1.0; ghost = true, initial_red = [1, 2])
         GraphEpimodels._ce_catch!(p, 1)
 
         @test get_node_state(g, 1) == REMOVED
@@ -113,7 +113,7 @@
     end
 
     @testset "Monotonicity & conservation" begin
-        p = create_chase_escape_simulation(15, 15, 3.0; rng_seed = 7)
+        p = create_chase_escape_process(15, 15, 3.0; rng_seed = 7)
         g = get_graph(p)
         n = num_nodes(g)
         states = node_states_raw(g)
@@ -139,11 +139,11 @@
     end
 
     @testset "Determinism" begin
-        p1 = create_chase_escape_simulation(20, 20, 2.5; rng_seed = 123)
+        p1 = create_chase_escape_process(20, 20, 2.5; rng_seed = 123)
         run_simulation(p1)
         s1 = get_chase_escape_statistics(p1)
 
-        p2 = create_chase_escape_simulation(20, 20, 2.5; rng_seed = 123)
+        p2 = create_chase_escape_process(20, 20, 2.5; rng_seed = 123)
         run_simulation(p2)
         s2 = get_chase_escape_statistics(p2)
 
@@ -155,7 +155,7 @@
 
     @testset "Edge cases" begin
         # Single-node lattice: only a ghost-catch is possible.
-        p = create_chase_escape_simulation(1, 1, 2.0; ghost = true)
+        p = create_chase_escape_process(1, 1, 2.0; ghost = true)
         g = get_graph(p)
         @test num_nodes(g) == 1
         @test is_active(p)                 # ghost makes the lone red catchable
@@ -167,7 +167,7 @@
 
         # Red seed with no white neighbours but an explicit blue neighbour.
         g2 = create_path_graph(2)
-        p2 = create_chase_escape_simulation(
+        p2 = create_chase_escape_process(
             g2, 2.0, 1.0; ghost = false, initial_red = [1], initial_blue = [2])
         @test is_active(p2)
         run_simulation(p2)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -23,7 +23,7 @@ network_graphs() = [
 
 # An SIR process on a graph, infected starting from node 1 (deterministic and
 # valid for every graph type, including those without a center node).
-sir_on(g) = create_sir_simulation(g, 0.6, 1.0; initial_infected = [1], rng_seed = 1)
+sir_on(g) = create_sir_process(g, 0.6, 1.0; initial_infected = [1], rng_seed = 1)
 
 @testset "visualization" begin
 


### PR DESCRIPTION
## Summary

- **Rename `create_X_simulation` → `create_X_process`** for all four model factories (`SIR`, `ZIM`, `MakiThompson`, `ChaseEscape`). The old names were inconsistent with their return types (`XProcess`) and the `AbstractEpidemicProcess` type hierarchy.
- **Extract `resolve_initial_nodes` helper** into `src/core/utils.jl`. The `:center`/`:random`/explicit node resolution block was copy-pasted verbatim into all four factory functions — none of that logic was model-specific. It now lives in one place.
- **Fix stale `isdefined` guard** in `sir.jl` that used `isdefined(graph, :get_center_node) || hasmethod(...)` while every other model used just `hasmethod(...)`.

All call sites updated: exports in `GraphEpimodels.jl`, docstring examples, `survival_analysis.jl`, `persistence.jl`, `animation.jl`, tests, and example scripts. No behaviour changes — all 1188 tests pass.

## Test plan

- [x] `Pkg.test()` — all 1188 tests pass
- [x] Grep confirms zero remaining `create_X_simulation` references