### PR TITLE
Add 3D visualization + RegularTree degree conventions

### DIFF
--- a/ext/GraphEpimodelsCairoMakieExt.jl
+++ b/ext/GraphEpimodelsCairoMakieExt.jl
@@ -57,6 +57,16 @@ function _lattice_axis(viz::LatticeVisualizer; title::String = "",
                       transparent_background = transparent_background)
 end
 
+"""Create a clean figure + 3D axis (equal aspect, no decorations) for node-link frames."""
+function _make_axis3(figure_size::Tuple{Int,Int}; title::String = "",
+                     transparent_background::Bool = false)
+    bg = transparent_background ? :transparent : :white
+    fig = Figure(size = figure_size, backgroundcolor = bg)
+    ax = Axis3(fig[1, 1]; title = title, aspect = :data, backgroundcolor = bg)
+    hidedecorations!(ax)
+    return fig, ax
+end
+
 """
 Render a single lattice state (raw Int8 vector) to a Makie `Figure`.
 
@@ -171,21 +181,28 @@ ignored for node-link graphs.
 - `transparent_background::Bool`: Transparent background + susceptible cells (lattices only; default: false)
 - `show_boundary::Bool`: Outline the lattice boundary (lattices only; default: false)
 - `show_grid::Bool`: Stroke cell outlines (cell lattices only; default: false)
+- `dim::Int`: Drawing dimension, 2 or 3 (node-link graphs only; default: 2). `dim = 3`
+  draws the graph in 3D — an intrinsic 3D layout where available (star / complete /
+  tree), otherwise a 3D force-directed layout. Lattices support 2D only.
 """
 function GraphEpimodels.save_plot(process::AbstractEpidemicProcess, filename::String;
                                           color_scheme::Union{Symbol, Nothing} = nothing,
                                           figure_size::Tuple{Int, Int} = (800, 800),
                                           transparent_background::Bool = false,
                                           show_boundary::Bool = false,
-                                          show_grid::Bool = false)
+                                          show_grid::Bool = false,
+                                          dim::Int = 2)
     scheme = color_scheme === nothing ? default_color_scheme(process) : color_scheme
     graph = get_graph(process)
     viz = visualizer_for(graph; color_scheme = scheme, figure_size = figure_size)
     if viz isa LatticeVisualizer
+        dim == 2 || throw(ArgumentError(
+            "$(typeof(graph)) renders in 2D only (got dim=$dim); lattices have no 3D layout"))
         viz.show_boundary = show_boundary
         viz.show_grid = show_grid
         fig = visualize_state(viz, process; transparent_background = transparent_background)
     else
+        viz.dim = dim
         fig = visualize_state(viz, process)
     end
     save(filename, fig)
@@ -198,51 +215,89 @@ end
 # =============================================================================
 
 """
-Resolve node positions for a graph: attached coordinates if present, else a
-force-directed (spring) layout. Returns a `2 × n` `Matrix{Float64}`.
+Resolve node positions for a graph in `dim` dimensions (2 or 3). Returns a
+`dim × n` `Matrix{Float64}`.
 
-Works for any `AbstractEpidemicGraph`: structured implicit graphs and lattices
-carry an intrinsic layout (`has_layout`), an `ErdosRenyiGraph` forwards the layout
-of its wrapped graph, and a bare `AdjacencyGraph` with no coordinates falls back
-to a spring layout.
+Resolution order:
+1. If the graph has an intrinsic layout for `dim` (`dim ∈ supported_layout_dims`),
+   use it (star sphere, tree shells, lattice grid, attached coordinates, …).
+2. Else if it has an intrinsic layout of *higher* dimension, project onto the
+   first `dim` axes (e.g. draw a graph with attached 3D coords in 2D).
+3. Else fall back to a force-directed (spring) layout computed in `dim` dimensions.
+
+Works for any `AbstractEpidemicGraph`: an `ErdosRenyiGraph` forwards the layout of
+its wrapped graph, and a bare `AdjacencyGraph` with no coordinates falls back to a
+spring layout.
 """
-function _resolve_positions(graph::AbstractEpidemicGraph)::Matrix{Float64}
-    if has_layout(graph)
-        pos = node_positions(graph)
-        return size(pos, 1) == 2 ? pos : pos[1:2, :]   # drop z for 2D draw
+function _resolve_positions(graph::AbstractEpidemicGraph; dim::Int = 2)::Matrix{Float64}
+    if dim in supported_layout_dims(graph)
+        return node_positions(graph; dim = dim)
+    end
+    ld = layout_dim(graph)
+    if ld > dim
+        return node_positions(graph; dim = ld)[1:dim, :]   # project higher-dim layout
     end
     n = num_nodes(graph)
     adj = falses(n, n)
     @inbounds for i in 1:n, j in get_neighbors(graph, i)
         adj[i, j] = true
     end
-    pts = NetworkLayout.spring(adj; seed = 1)
-    mat = Matrix{Float64}(undef, 2, n)
-    @inbounds for i in 1:n
-        mat[1, i] = pts[i][1]
-        mat[2, i] = pts[i][2]
+    pts = NetworkLayout.spring(adj; dim = dim, seed = 1)
+    mat = Matrix{Float64}(undef, dim, n)
+    @inbounds for i in 1:n, d in 1:dim
+        mat[d, i] = pts[i][d]
     end
     return mat
 end
 
-"""Draw a network frame into an existing axis (edges + colored node markers)."""
+# Convert a `dim × n` coordinate matrix to a vector of Makie points, picking
+# Point3f for a 3-row matrix and Point2f otherwise. Used for both nodes and edges
+# so the 2D and 3D draw paths share one code path.
+function _to_points(pos::AbstractMatrix{<:Real})
+    n = size(pos, 2)
+    if size(pos, 1) == 3
+        return [Point3f(pos[1, i], pos[2, i], pos[3, i]) for i in 1:n]
+    end
+    return [Point2f(pos[1, i], pos[2, i]) for i in 1:n]
+end
+
+"""Create a node-link axis: 2D `Axis` (equal aspect) or 3D `Axis3` per `viz.dim`."""
+function _network_axis(fig, viz::NetworkVisualizer; title::String = "")
+    if viz.dim == 3
+        ax = Axis3(fig[1, 1]; title = title, aspect = :data)
+        hidedecorations!(ax)
+        return ax
+    end
+    ax = Axis(fig[1, 1]; title = title, aspect = DataAspect())
+    hidedecorations!(ax)
+    hidespines!(ax)
+    return ax
+end
+
+"""
+Draw a network frame into an existing axis (edges + colored node markers).
+
+Works in 2D and 3D: the drawing dimension follows the coordinate matrix (2 or 3
+rows), so the same code renders into an `Axis` or an `Axis3`.
+"""
 function _draw_network!(ax, viz::NetworkVisualizer, graph::AbstractEpidemicGraph,
                         states_raw::Vector{Int8};
                         positions::Union{Matrix{Float64}, Nothing} = nothing)
-    pos = positions === nothing ? _resolve_positions(graph) : positions
+    pos = positions === nothing ? _resolve_positions(graph; dim = viz.dim) : positions
+    pts = _to_points(pos)
 
     if viz.show_edges
-        segs = Point2f[]
+        segs = eltype(pts)[]
         @inbounds for i in 1:num_nodes(graph), j in get_neighbors(graph, i)
             i < j || continue
-            push!(segs, Point2f(pos[1, i], pos[2, i]))
-            push!(segs, Point2f(pos[1, j], pos[2, j]))
+            push!(segs, pts[i])
+            push!(segs, pts[j])
         end
         isempty(segs) || linesegments!(ax, segs; color = viz.edge_color)
     end
 
     colors = _node_colors(viz.color_scheme, states_raw)
-    scatter!(ax, pos[1, :], pos[2, :]; color = colors, markersize = viz.node_size,
+    scatter!(ax, pts; color = colors, markersize = viz.node_size,
              strokewidth = 0.5, strokecolor = :black)
     return ax
 end
@@ -251,9 +306,7 @@ function GraphEpimodels.render_frame(viz::NetworkVisualizer, graph::AbstractEpid
                                      states_raw::Vector{Int8}; title::String = "",
                                      positions::Union{Matrix{Float64}, Nothing} = nothing)
     fig = Figure(size = viz.figure_size)
-    ax = Axis(fig[1, 1]; title = title, aspect = DataAspect())
-    hidedecorations!(ax)
-    hidespines!(ax)
+    ax = _network_axis(fig, viz; title = title)
     _draw_network!(ax, viz, graph, states_raw; positions = positions)
     return fig
 end
@@ -288,6 +341,18 @@ function _frame_limits(positions::Matrix{Float64})
     return (xlo - mx, xhi + mx, ylo - my, yhi + my)
 end
 
+"""Apply fixed 3D limits (with margin) to an `Axis3` so the view stays steady."""
+function _apply_limits3!(ax, positions::Matrix{Float64})
+    xlo, xhi = extrema(@view positions[1, :])
+    ylo, yhi = extrema(@view positions[2, :])
+    zlo, zhi = extrema(@view positions[3, :])
+    mx = 0.05 * (xhi - xlo) + 0.5
+    my = 0.05 * (yhi - ylo) + 0.5
+    mz = 0.05 * (zhi - zlo) + 0.5
+    limits!(ax, xlo - mx, xhi + mx, ylo - my, yhi + my, zlo - mz, zhi + mz)
+    return ax
+end
+
 """
 Render a recording to an animated GIF or MP4 (format from the filename extension).
 
@@ -308,6 +373,12 @@ node-link diagram.
 - `figure_size::Tuple{Int, Int}`: Frame size in pixels (default: (600, 600))
 - `show_boundary::Bool`: Outline the lattice boundary (lattices only; default: false)
 - `show_grid::Bool`: Stroke cell outlines (cell lattices only; default: false)
+- `dim::Int`: Drawing dimension, 2 or 3 (node-link graphs only; default: 2). `dim = 3`
+  draws an intrinsic 3D layout where available (star / complete / tree), else a 3D
+  force-directed one. Ignored when an explicit `visualizer` is supplied (it carries
+  its own `dim`). Lattices support 2D only.
+- `turntable::Bool`: For 3D animations, slowly rotate the camera one full turn over
+  the clip (default: false). No effect in 2D.
 - `visualizer::Union{AbstractVisualizer, Nothing}`: Override the auto-selected
   visualizer (default: `nothing` → chosen by graph type).
 
@@ -323,11 +394,19 @@ function GraphEpimodels.animate_recording(rec::SimulationRecording;
                                           show_grid::Bool = false,
                                           show_title::Bool = true,
                                           transparent_background::Bool = false,
+                                          dim::Int = 2,
+                                          turntable::Bool = false,
                                           visualizer::Union{AbstractVisualizer, Nothing} = nothing)
     graph = rec.graph
     if visualizer === nothing
         scheme = color_scheme === nothing ? default_color_scheme(rec.process_name) : color_scheme
         viz = visualizer_for(graph; color_scheme = scheme, figure_size = figure_size)
+        if viz isa NetworkVisualizer
+            viz.dim = dim
+        elseif dim != 2
+            throw(ArgumentError(
+                "$(typeof(graph)) renders in 2D only (got dim=$dim); lattices have no 3D layout"))
+        end
     else
         viz = visualizer
     end
@@ -336,16 +415,26 @@ function GraphEpimodels.animate_recording(rec::SimulationRecording;
         viz.show_grid = show_grid
     end
 
+    is3d = viz isa NetworkVisualizer && viz.dim == 3
+
     # A general (node-link) graph gets a single fixed layout so nodes don't move
     # between frames; lattices use their intrinsic node positions.
-    positions = viz isa NetworkVisualizer ? _resolve_positions(graph) :
+    positions = viz isa NetworkVisualizer ? _resolve_positions(graph; dim = viz.dim) :
                 node_positions(graph)
-    xlo, xhi, ylo, yhi = _frame_limits(positions)
 
     title0 = show_title ? _frame_title(rec, 1) : ""
-    fig, ax = _make_axis(figure_size; title = title0,
-                         transparent_background = transparent_background)
-    limits!(ax, xlo, xhi, ylo, yhi)
+    if is3d
+        fig, ax = _make_axis3(figure_size; title = title0,
+                              transparent_background = transparent_background)
+        _apply_limits3!(ax, positions)
+        base_azimuth = ax.azimuth[]
+    else
+        fig, ax = _make_axis(figure_size; title = title0,
+                             transparent_background = transparent_background)
+        xlo, xhi, ylo, yhi = _frame_limits(positions)
+        limits!(ax, xlo, xhi, ylo, yhi)
+        base_azimuth = 0.0
+    end
 
     layout_pos = viz isa NetworkVisualizer ? positions : nothing
     n = num_frames(rec)
@@ -353,6 +442,12 @@ function GraphEpimodels.animate_recording(rec::SimulationRecording;
         empty!(ax)
         if show_title
             ax.title = _frame_title(rec, idx)
+        end
+        if is3d
+            _apply_limits3!(ax, positions)   # keep limits steady across frames
+            if turntable
+                ax.azimuth[] = base_azimuth + 2π * (idx - 1) / n
+            end
         end
         _draw_frame!(ax, viz, graph, rec.frames[idx];
                      positions = layout_pos,
@@ -392,6 +487,8 @@ function GraphEpimodels.animate_simulation(process::AbstractEpidemicProcess;
                                            show_grid::Bool = false,
                                            show_title::Bool = true,
                                            transparent_background::Bool = false,
+                                           dim::Int = 2,
+                                           turntable::Bool = false,
                                            visualizer::Union{AbstractVisualizer, Nothing} = nothing)::SimulationRecording
     rec = record_simulation(process;
                             sampler = sampler,
@@ -408,6 +505,8 @@ function GraphEpimodels.animate_simulation(process::AbstractEpidemicProcess;
                       show_grid = show_grid,
                       show_title = show_title,
                       transparent_background = transparent_background,
+                      dim = dim,
+                      turntable = turntable,
                       visualizer = visualizer)
 
     return rec

--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -68,7 +68,7 @@ export count_states, get_nodes_in_state, count_neighbors_by_state
 export get_active_edges
 
 # Geometry interface (consumed by visualization)
-export has_layout, layout_dim, node_positions, has_cells, cell_polygons
+export supported_layout_dims, has_layout, layout_dim, node_positions, has_cells, cell_polygons
 
 # Square lattice implementation
 include("graphs/lattice.jl")

--- a/src/GraphEpimodels.jl
+++ b/src/GraphEpimodels.jl
@@ -103,7 +103,7 @@ export CycleGraph, create_cycle_graph
 include("graphs/star.jl")
 export StarGraph, create_star_graph
 include("graphs/regular_tree.jl")
-export RegularTree, create_regular_tree
+export RegularTree, create_regular_tree, create_dary_tree
 
 # =============================================================================
 # Epidemic Process Framework

--- a/src/graphs/adjacency.jl
+++ b/src/graphs/adjacency.jl
@@ -124,12 +124,15 @@ end
 # It never fills space with cells, so the visualizer draws it as a node-link
 # diagram (markers + edges), computing a layout when none is attached.
 
-has_layout(graph::AdjacencyGraph)::Bool = graph.coords !== nothing
-layout_dim(graph::AdjacencyGraph)::Int = graph.coords === nothing ? 0 : size(graph.coords, 1)
+# The intrinsic dims are exactly the dimension of the attached coordinates (2 or
+# 3), or none when no coordinates have been attached.
+supported_layout_dims(graph::AdjacencyGraph)::Tuple{Vararg{Int}} =
+    graph.coords === nothing ? () : (size(graph.coords, 1),)
 
-function node_positions(graph::AdjacencyGraph)::Matrix{Float64}
+function node_positions(graph::AdjacencyGraph; dim::Int = layout_dim(graph))::Matrix{Float64}
     graph.coords === nothing &&
         error("AdjacencyGraph has no attached coordinates; has_layout() is false")
+    _check_layout_dim(graph, dim)
     return graph.coords
 end
 

--- a/src/graphs/complete.jl
+++ b/src/graphs/complete.jl
@@ -119,15 +119,16 @@ end
 # =============================================================================
 #
 # A complete graph has no intrinsic embedding, but the conventional drawing places
-# the nodes evenly on a circle so every edge is visible. Providing this gives a
-# deterministic layout instead of falling back to a computed (force-directed) one.
-# It is not a space-filling tiling, so it supplies no cells.
+# the nodes evenly on a circle (2D) or sphere (3D) so connections spread out. This
+# gives a deterministic layout instead of falling back to a computed (force-directed)
+# one. It is not a space-filling tiling, so it supplies no cells.
 
-has_layout(::CompleteGraph)::Bool = true
-layout_dim(::CompleteGraph)::Int = 2
+supported_layout_dims(::CompleteGraph)::Tuple{Vararg{Int}} = (2, 3)
 
-function node_positions(graph::CompleteGraph)::Matrix{Float64}
+function node_positions(graph::CompleteGraph; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(graph, dim)
     n = graph.n_nodes
+    dim == 3 && return _fibonacci_sphere(n)   # all nodes on the unit sphere
     pos = Matrix{Float64}(undef, 2, n)
     @inbounds for idx in 1:n
         θ = 2π * (idx - 1) / n

--- a/src/graphs/cycle.jl
+++ b/src/graphs/cycle.jl
@@ -113,10 +113,10 @@ end
 # A cycle is drawn with its nodes evenly spaced on the unit circle, so adjacent
 # indices are adjacent on the ring. It is not a space-filling tiling (no cells).
 
-has_layout(::CycleGraph)::Bool = true
-layout_dim(::CycleGraph)::Int = 2
+supported_layout_dims(::CycleGraph)::Tuple{Vararg{Int}} = (2,)
 
-function node_positions(graph::CycleGraph)::Matrix{Float64}
+function node_positions(graph::CycleGraph; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(graph, dim)
     n = graph.n_nodes
     pos = Matrix{Float64}(undef, 2, n)
     @inbounds for idx in 1:n

--- a/src/graphs/erdos_renyi.jl
+++ b/src/graphs/erdos_renyi.jl
@@ -66,9 +66,9 @@ count_neighbors_by_state(g::ErdosRenyiGraph, node_id::Int, target_state::NodeSta
 
 # Geometry interface (delegated; an ER graph has a layout only if coordinates were
 # attached to the inner graph — see set_coords! below).
-has_layout(g::ErdosRenyiGraph)::Bool = has_layout(g.graph)
-layout_dim(g::ErdosRenyiGraph)::Int = layout_dim(g.graph)
-node_positions(g::ErdosRenyiGraph)::Matrix{Float64} = node_positions(g.graph)
+supported_layout_dims(g::ErdosRenyiGraph)::Tuple{Vararg{Int}} = supported_layout_dims(g.graph)
+node_positions(g::ErdosRenyiGraph; dim::Int = layout_dim(g))::Matrix{Float64} =
+    node_positions(g.graph; dim = dim)
 
 """Attach (or replace) node coordinates for plotting (`dim × n`)."""
 set_coords!(g::ErdosRenyiGraph, coords::AbstractMatrix{<:Real}) = (set_coords!(g.graph, coords); g)

--- a/src/graphs/graphs.jl
+++ b/src/graphs/graphs.jl
@@ -221,37 +221,99 @@ end
 # computed layout.
 
 """
-Whether the graph carries an intrinsic (or attached) spatial layout.
+The intrinsic layout dimensions a graph type can produce, as a tuple of `Int`s.
 
-Default: `false`. Lattices return `true`; an `AdjacencyGraph` returns `true`
-only when node coordinates have been attached.
+This is the primary geometry-capability query: it lists every dimension `d` for
+which the type knows a *closed-form* embedding, in preference order (so the first
+entry is the "natural" one). Examples:
+
+- `()`            — no intrinsic layout (e.g. a bare `AdjacencyGraph`); the
+  visualizer falls back to a force-directed layout in whatever dimension it draws.
+- `(2,)`          — a planar-only layout (lattices, cycle, path).
+- `(2, 3)`        — both a 2D and a 3D closed-form layout (star, complete, tree).
+
+A type advertises a dimension here *only* when it has a meaningful built-in
+embedding for it. "Can it be drawn in 3D at all?" is a different (and almost
+always `true`) question answered by the force-directed fallback, not by this.
+
+Default: `()`. `has_layout` and `layout_dim` are derived from this.
 """
-function has_layout(graph::AbstractEpidemicGraph)::Bool
-    return false
+function supported_layout_dims(graph::AbstractEpidemicGraph)::Tuple{Vararg{Int}}
+    return ()
 end
 
 """
-Dimensionality of the node layout (2 or 3); `0` when there is no layout.
+Whether the graph carries an intrinsic (or attached) spatial layout.
 
-Default: `0`. 2D graphs return `2`; this becomes `3` for future 3D graphs with
-no change to the rest of the interface.
+Derived from [`supported_layout_dims`](@ref): `true` iff the graph advertises at
+least one intrinsic layout dimension. Lattices and the structured graphs return
+`true`; an `AdjacencyGraph` returns `true` only when node coordinates have been
+attached.
+"""
+has_layout(graph::AbstractEpidemicGraph)::Bool = !isempty(supported_layout_dims(graph))
+
+"""
+The *preferred* layout dimension (2 or 3); `0` when there is no layout.
+
+Derived from [`supported_layout_dims`](@ref) as its first entry — the dimension
+used when `node_positions` is called without an explicit `dim`. 2D graphs return
+`2`; a graph whose natural embedding is 3D returns `3`.
 """
 function layout_dim(graph::AbstractEpidemicGraph)::Int
-    return 0
+    dims = supported_layout_dims(graph)
+    return isempty(dims) ? 0 : first(dims)
+end
+
+"""
+Validate that `dim` is one of the graph's [`supported_layout_dims`](@ref).
+
+Concrete `node_positions` methods call this first so an unsupported `dim` gives a
+clear error instead of silently wrong coordinates.
+"""
+@inline function _check_layout_dim(graph::AbstractEpidemicGraph, dim::Int)
+    dim in supported_layout_dims(graph) && return nothing
+    throw(ArgumentError(
+        "$(typeof(graph)) supports layout dims $(supported_layout_dims(graph)); got dim=$dim"))
 end
 
 """
 Node coordinates as a `dim × N` matrix (column `i` is the position of node `i`).
 
-Using `dim × N` (rather than `N × dim`) keeps each node's coordinates
-contiguous in Julia's column-major storage and makes the 3D extension a pure
-shape change (`2 × N` → `3 × N`).
+`dim` selects which intrinsic layout to produce and must be one of the graph's
+[`supported_layout_dims`](@ref); it defaults to the preferred [`layout_dim`](@ref).
+Using `dim × N` (rather than `N × dim`) keeps each node's coordinates contiguous
+in Julia's column-major storage, so a 2D vs 3D layout is just a different row
+count (`2 × N` vs `3 × N`).
 
-No default: graphs that report `has_layout() == true` must implement this.
+No default: graphs that report a non-empty `supported_layout_dims` must implement this.
 """
-function node_positions(graph::AbstractEpidemicGraph)::Matrix{Float64}
+function node_positions(graph::AbstractEpidemicGraph;
+                        dim::Int = layout_dim(graph))::Matrix{Float64}
     error("node_positions must be implemented by graph type $(typeof(graph)) " *
-          "that reports has_layout() == true")
+          "that reports a non-empty supported_layout_dims()")
+end
+
+"""
+Evenly distributed points on the unit sphere via the golden-angle (Fibonacci)
+spiral. Returns a `3 × n` matrix whose columns are unit vectors.
+
+Shared by the closed-form 3D layouts (star sphere, complete-graph sphere, and the
+per-level shells of a tree). The spiral spaces points near-uniformly for any `n`,
+avoiding the clustering of naive lat/long grids.
+"""
+function _fibonacci_sphere(n::Int)::Matrix{Float64}
+    pos = Matrix{Float64}(undef, 3, n)
+    n == 0 && return pos
+    golden = π * (3 - sqrt(5))            # golden angle ≈ 2.39996 rad
+    @inbounds for i in 0:(n - 1)
+        y = 1 - 2 * (i + 0.5) / n          # y from ~+1 down to ~-1
+        r = sqrt(max(0.0, 1 - y * y))      # circle radius at height y
+        θ = golden * i
+        pos[1, i + 1] = r * cos(θ)
+        pos[2, i + 1] = y
+        pos[3, i + 1] = r * sin(θ)
+    end
+    return pos
 end
 
 """

--- a/src/graphs/hexagonal_lattice.jl
+++ b/src/graphs/hexagonal_lattice.jl
@@ -145,8 +145,7 @@ end
 # is a regular hexagon. The dual cell is an equilateral triangle of circumradius
 # 1 centered on the node, pointing down when (row + col) is even and up when odd.
 
-has_layout(::HexagonalLattice)::Bool = true
-layout_dim(::HexagonalLattice)::Int = 2
+supported_layout_dims(::HexagonalLattice)::Tuple{Vararg{Int}} = (2,)
 has_cells(::HexagonalLattice)::Bool = true
 
 @inline function _hex_node_xy(row::Int, col::Int)::Tuple{Float64, Float64}
@@ -155,7 +154,8 @@ has_cells(::HexagonalLattice)::Bool = true
     return (x, y)
 end
 
-function node_positions(lattice::HexagonalLattice)::Matrix{Float64}
+function node_positions(lattice::HexagonalLattice; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(lattice, dim)
     n = lattice.n_nodes
     pos = Matrix{Float64}(undef, 2, n)
     @inbounds for idx in 1:n

--- a/src/graphs/lattice.jl
+++ b/src/graphs/lattice.jl
@@ -362,11 +362,11 @@ end
 # Its dual cell is the unit square centered on that point — the square tiling is
 # self-dual, so each of the 4 cell edges corresponds to one of the 4 neighbors.
 
-has_layout(::SquareLattice)::Bool = true
-layout_dim(::SquareLattice)::Int = 2
+supported_layout_dims(::SquareLattice)::Tuple{Vararg{Int}} = (2,)
 has_cells(::SquareLattice)::Bool = true
 
-function node_positions(lattice::SquareLattice)::Matrix{Float64}
+function node_positions(lattice::SquareLattice; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(lattice, dim)
     n = lattice.n_nodes
     pos = Matrix{Float64}(undef, 2, n)
     @inbounds for idx in 1:n

--- a/src/graphs/path.jl
+++ b/src/graphs/path.jl
@@ -114,10 +114,10 @@ end
 # A path is drawn as collinear nodes: node i sits at (i, 0). It is not a
 # space-filling tiling, so it supplies no cells.
 
-has_layout(::PathGraph)::Bool = true
-layout_dim(::PathGraph)::Int = 2
+supported_layout_dims(::PathGraph)::Tuple{Vararg{Int}} = (2,)
 
-function node_positions(graph::PathGraph)::Matrix{Float64}
+function node_positions(graph::PathGraph; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(graph, dim)
     n = graph.n_nodes
     pos = Matrix{Float64}(undef, 2, n)
     @inbounds for idx in 1:n

--- a/src/graphs/regular_tree.jl
+++ b/src/graphs/regular_tree.jl
@@ -1,14 +1,24 @@
 """
-Regular rooted k-ary tree implementation for epidemic modeling.
+Regular rooted tree implementations for epidemic modeling.
 
-A *regular rooted tree* of branching factor `k` and height `h` has
-`n = (kʰ − 1) ÷ (k − 1)` nodes in `h` levels. The root (node 1) is at level 1
-and has `k` children; every internal node has `k` children and one parent; every
-leaf has one parent. Node numbering follows 1-indexed BFS (heap) order, so
-parent/child indices reduce to O(1) arithmetic:
+This file provides a single [`RegularTree`](@ref) type that covers two common
+rooted-tree conventions, distinguished only by how many children non-root
+internal nodes have:
 
-- Parent of node `i > 1`:  `(i − 2) ÷ k + 1`
-- Children of node `i`:    `k(i − 1) + 2` through `ki + 1` (if ≤ n)
+- **Graph-theory regular tree** (Cayley tree / Bethe lattice), via
+  [`create_regular_tree`](@ref): *every* internal vertex has degree `d`, so the
+  root has `d` children and each non-root internal node has `d − 1` children (one
+  edge goes to its parent). This is the canonical regular tree in
+  percolation/branching-process analysis — the branching ratio `d − 1` is exactly
+  what governs the epidemic threshold — and is the default meaning of "regular
+  tree".
+- **Balanced d-ary tree** (the computer-science convention), via
+  [`create_dary_tree`](@ref): *every* internal node, root included, has `k`
+  children (so non-root internal nodes have degree `k + 1`).
+
+Node numbering is 1-indexed BFS (level) order in both cases. Because every level
+is complete and every internal node at a given "tier" has the same number of
+children, parent/child indices reduce to O(1) arithmetic (see the helpers below).
 
 Like [`StarGraph`](@ref) and [`PathGraph`](@ref), this is an
 [`AbstractImplicitGraph`](@ref): only the state vector is stored; no adjacency
@@ -20,30 +30,72 @@ lists are materialized.
 # =============================================================================
 
 """
-Regular rooted k-ary tree with branching factor `k` and `h` levels.
+Regular rooted tree with `height` levels, parametrized by two child counts.
 
-Node numbering is BFS level-order (1-indexed heap): root = 1,
-level-1 nodes = 2..k+1, level-2 nodes = k+2..k²+k+1, and so on.
+The root (node 1) has `root_children` children; every *non-root* internal node
+has `branching` children. The two public constructors set these:
+[`create_regular_tree`](@ref) (Cayley: `root_children = d`, `branching = d − 1`)
+and [`create_dary_tree`](@ref) (d-ary: `root_children = branching = k`).
+
+Node numbering is BFS level-order (1-indexed): root = 1, then level 1, etc.
 
 # Fields
-- `branching_factor::Int`: Children per internal node (`k ≥ 2`)
+- `root_children::Int`: Number of children of the root
+- `branching::Int`: Number of children of each non-root internal node
 - `height::Int`: Number of levels (`h ≥ 1`; `h = 1` = root only)
-- `n_nodes::Int`: Total nodes `= (kʰ − 1) ÷ (k − 1)`
+- `n_nodes::Int`: Total number of nodes
 - `states::Vector{Int8}`: Node states (primitive array)
 """
 mutable struct RegularTree <: AbstractImplicitGraph
-    branching_factor::Int
+    root_children::Int
+    branching::Int
     height::Int
     n_nodes::Int
     states::Vector{Int8}
 
-    function RegularTree(branching_factor::Int, height::Int)
-        k, h = branching_factor, height
-        k >= 2 || throw(ArgumentError("branching_factor must be ≥ 2, got $k"))
-        h >= 1 || throw(ArgumentError("height must be ≥ 1, got $h"))
-        n = (k^h - 1) ÷ (k - 1)
-        new(k, h, n, zeros(Int8, n))
+    function RegularTree(root_children::Int, branching::Int, height::Int)
+        root_children >= 1 || throw(ArgumentError("root_children must be ≥ 1, got $root_children"))
+        branching >= 1 || throw(ArgumentError("branching must be ≥ 1, got $branching"))
+        height >= 1 || throw(ArgumentError("height must be ≥ 1, got $height"))
+        n = _tree_n_nodes(root_children, branching, height)
+        new(root_children, branching, height, n, zeros(Int8, n))
     end
+end
+
+"""
+Total node count of a tree whose root has `R` children, whose other internal
+nodes have `b` children, and which has `h` complete levels.
+
+`n = 1 + R·(b^(h-1) − 1)/(b − 1)`, with the `b == 1` case (a path-like tree)
+handled separately to avoid dividing by zero.
+"""
+function _tree_n_nodes(R::Int, b::Int, h::Int)::Int
+    h == 1 && return 1
+    b == 1 && return 1 + R * (h - 1)
+    return 1 + R * (b^(h - 1) - 1) ÷ (b - 1)
+end
+
+# =============================================================================
+# Child / parent index arithmetic (O(1), shared by topology and layout)
+# =============================================================================
+#
+# BFS order fills the root's `R` children into indices 2..R+1, then each
+# subsequent node contributes `b` children. So for node i ≥ 2 the first child is
+# at R + 2 + (i-2)·b, and the parent inverts that.
+
+@inline _num_children(tree::RegularTree, i::Int)::Int =
+    i == 1 ? tree.root_children : tree.branching
+
+@inline function _first_child(tree::RegularTree, i::Int)::Int
+    i == 1 && return 2
+    return tree.root_children + 2 + (i - 2) * tree.branching
+end
+
+@inline function _parent(tree::RegularTree, i::Int)::Int
+    # Caller guarantees i ≥ 2.
+    R = tree.root_children
+    i <= R + 1 && return 1
+    return 2 + (i - R - 2) ÷ tree.branching
 end
 
 # =============================================================================
@@ -70,21 +122,21 @@ function get_neighbors(tree::RegularTree, node_id::Int)::Vector{Int}
 end
 
 function get_neighbors!(neighbors::Vector{Int}, tree::RegularTree, node_id::Int)::Vector{Int}
-    k, n = tree.branching_factor, tree.n_nodes
+    n = tree.n_nodes
     if node_id < 1 || node_id > n
         throw(BoundsError("Node ID $node_id out of range [1, $n]"))
     end
     empty!(neighbors)
 
-    # Parent: every node except the root has one
+    # Parent: every node except the root has one.
     if node_id > 1
-        push!(neighbors, (node_id - 2) ÷ k + 1)
+        push!(neighbors, _parent(tree, node_id))
     end
 
-    # Children: k nodes at heap positions k(i-1)+2 .. ki+1
-    first_child = k * (node_id - 1) + 2
+    # Children: a contiguous block in BFS order.
+    first_child = _first_child(tree, node_id)
     if first_child <= n
-        last_child = min(k * node_id + 1, n)
+        last_child = min(first_child + _num_children(tree, node_id) - 1, n)
         sizehint!(neighbors, length(neighbors) + last_child - first_child + 1)
         @inbounds for c in first_child:last_child
             push!(neighbors, c)
@@ -94,38 +146,69 @@ function get_neighbors!(neighbors::Vector{Int}, tree::RegularTree, node_id::Int)
     return neighbors
 end
 
-# Degree: root has k children (or 0 if the tree is a single node), leaves have
-# degree 1 (one parent), internal nodes have k children + 1 parent.
+# Degree: root has `root_children` (or 0 for a single-node tree); a node with no
+# children is a leaf (degree 1, just its parent); other non-root nodes have
+# `branching` children + 1 parent.
 @inline function get_node_degree(tree::RegularTree, node_id::Int)::Int
-    k, n = tree.branching_factor, tree.n_nodes
+    n = tree.n_nodes
     if node_id < 1 || node_id > n
         throw(BoundsError("Node ID $node_id out of range [1, $n]"))
     end
-    node_id == 1 && return tree.height == 1 ? 0 : k
-    k * (node_id - 1) + 2 > n && return 1
-    return k + 1
+    node_id == 1 && return tree.height == 1 ? 0 : tree.root_children
+    _first_child(tree, node_id) > n && return 1
+    return tree.branching + 1
 end
 
 # =============================================================================
 # Geometry Interface (for visualization)
 # =============================================================================
 #
-# Root sits at the origin; level-l nodes are placed on a circle of radius l,
-# equally spaced in angle. This reflects the radial symmetry of the tree and
-# mirrors how infection spreads outward from the root.
+# Root sits at the origin; level-l nodes live on the shell of radius l — a circle
+# in 2D, a sphere in 3D — so radius encodes depth and the picture grows outward as
+# infection spreads from the root.
+#
+# Both layouts are *subtree-coherent*: a node's children are placed near it, so
+# edges fan outward instead of crossing the figure.
+# - 2D: nodes are equidistant on each circle, and each node sits at the CENTER of
+#   its angular arc (the `+0.5`). Because BFS numbering keeps a subtree's nodes
+#   contiguous, that arc is exactly the union of its children's arcs, so children
+#   straddle their parent — equidistant *and* coherent.
+# - 3D: a globally-equidistant sphere has no hierarchical nesting, so we start from
+#   a recursive cone-tree (each node fans its children into a shrinking cap around
+#   its own direction) and then run a short shell-constrained relaxation that
+#   spreads nodes evenly while pinning each to its shell — see `_relax_shells!`.
 
-has_layout(::RegularTree)::Bool = true
-layout_dim(::RegularTree)::Int = 2
+supported_layout_dims(::RegularTree)::Tuple{Vararg{Int}} = (2, 3)
 
-function node_positions(tree::RegularTree)::Matrix{Float64}
-    k, h, n = tree.branching_factor, tree.height, tree.n_nodes
+function node_positions(tree::RegularTree; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(tree, dim)
+    return dim == 3 ? _tree_positions_3d(tree) : _tree_positions_2d(tree)
+end
+
+# Number of nodes at level `l` (0-indexed): 1 at the root, then R·b^(l-1).
+@inline _level_count(tree::RegularTree, l::Int)::Int =
+    l == 0 ? 1 : tree.root_children * tree.branching^(l - 1)
+
+# Level (depth, 0-indexed) of every node, in BFS order.
+function _node_levels(tree::RegularTree)::Vector{Int}
+    levels = Vector{Int}(undef, tree.n_nodes)
+    idx = 1
+    @inbounds for l in 0:(tree.height - 1), _ in 1:_level_count(tree, l)
+        levels[idx] = l
+        idx += 1
+    end
+    return levels
+end
+
+function _tree_positions_2d(tree::RegularTree)::Matrix{Float64}
+    n = tree.n_nodes
     pos = Matrix{Float64}(undef, 2, n)
     node_idx = 1
-    @inbounds for level in 0:(h - 1)
-        level_count = k^level
+    @inbounds for level in 0:(tree.height - 1)
+        count = _level_count(tree, level)
         r = Float64(level)
-        for j in 0:(level_count - 1)
-            θ = 2π * j / level_count
+        for j in 0:(count - 1)
+            θ = 2π * (j + 0.5) / count   # center of this node's angular arc
             pos[1, node_idx] = r * cos(θ)
             pos[2, node_idx] = r * sin(θ)
             node_idx += 1
@@ -134,26 +217,205 @@ function node_positions(tree::RegularTree)::Matrix{Float64}
     return pos
 end
 
+# --- 3D cone-tree initial layout ----------------------------------------------
+
+# An orthonormal pair perpendicular to the unit vector `u`, used as the plane in
+# which a node spreads its children's azimuths.
+@inline function _perp_basis(u::NTuple{3,Float64})::NTuple{2,NTuple{3,Float64}}
+    # Cross `u` with whichever axis it is least aligned to (avoids degeneracy).
+    ax, ay, az = abs(u[1]), abs(u[2]), abs(u[3])
+    a = (ax <= ay && ax <= az) ? (1.0, 0.0, 0.0) :
+        (ay <= az ? (0.0, 1.0, 0.0) : (0.0, 0.0, 1.0))
+    e1 = _normalize3((u[2]*a[3] - u[3]*a[2], u[3]*a[1] - u[1]*a[3], u[1]*a[2] - u[2]*a[1]))
+    e2 = (u[2]*e1[3] - u[3]*e1[2], u[3]*e1[1] - u[1]*e1[3], u[1]*e1[2] - u[2]*e1[1])
+    return (e1, e2)
+end
+
+@inline function _normalize3(v::NTuple{3,Float64})::NTuple{3,Float64}
+    m = sqrt(v[1]^2 + v[2]^2 + v[3]^2)
+    return m == 0 ? v : (v[1]/m, v[2]/m, v[3]/m)
+end
+
+const _TREE_CONE_SPREAD = 0.6   # child polar offset as a fraction of the parent cap
+const _TREE_CONE_DECAY  = 0.55  # how much the cap narrows per level
+
+# Place node `g` at radius `level` along unit direction `u`, then recurse into its
+# children, fanning them around `u` within the cap `cap`.
+function _place_tree_node!(pos::Matrix{Float64}, tree::RegularTree,
+                           g::Int, u::NTuple{3,Float64}, level::Int, cap::Float64)
+    r = Float64(level)
+    @inbounds begin
+        pos[1, g] = r * u[1]
+        pos[2, g] = r * u[2]
+        pos[3, g] = r * u[3]
+    end
+    n = tree.n_nodes
+    first_child = _first_child(tree, g)
+    first_child > n && return
+    last_child = min(first_child + _num_children(tree, g) - 1, n)
+    nch = last_child - first_child + 1
+
+    e1, e2 = _perp_basis(u)
+    β = cap * _TREE_CONE_SPREAD
+    child_cap = cap * _TREE_CONE_DECAY
+    cβ, sβ = cos(β), sin(β)
+    for (idx, c) in enumerate(first_child:last_child)
+        az = 2π * (idx - 1) / nch
+        ca, sa = cos(az), sin(az)
+        t = (ca*e1[1] + sa*e2[1], ca*e1[2] + sa*e2[2], ca*e1[3] + sa*e2[3])
+        cu = (cβ*u[1] + sβ*t[1], cβ*u[2] + sβ*t[2], cβ*u[3] + sβ*t[3])
+        _place_tree_node!(pos, tree, c, _normalize3(cu), level + 1, child_cap)
+    end
+    return
+end
+
+# --- 3D shell-constrained relaxation ------------------------------------------
+
+const _TREE_RELAX_ITERS  = 300
+const _TREE_RELAX_REP     = 1.0    # repulsion strength
+const _TREE_RELAX_SPRING  = 0.4    # parent-child attraction strength
+const _TREE_RELAX_STEP0   = 0.08   # initial step (cooled over iterations)
+
+"""
+Even out the 3D layout while keeping its structure. Starting from the cone-tree
+positions, repeatedly apply inverse-square repulsion between all nodes and linear
+parent-child springs, then project every node back onto its shell (radius = its
+level). Repulsion spreads same-shell cousins apart; the springs and the radial
+projection keep subtrees coherent and the shell structure intact.
+
+Deterministic (no randomness) — the cone-tree seed makes the result reproducible.
+"""
+function _relax_shells!(pos::Matrix{Float64}, levels::Vector{Int}, tree::RegularTree)
+    n = size(pos, 2)
+    n <= 1 && return pos
+    force = zeros(Float64, 3, n)
+    for it in 1:_TREE_RELAX_ITERS
+        fill!(force, 0.0)
+        # Pairwise inverse-square repulsion.
+        @inbounds for i in 1:n
+            levels[i] == 0 && continue
+            for j in 1:n
+                i == j && continue
+                dx = pos[1, i] - pos[1, j]
+                dy = pos[2, i] - pos[2, j]
+                dz = pos[3, i] - pos[3, j]
+                d2 = dx*dx + dy*dy + dz*dz + 1e-6
+                inv = _TREE_RELAX_REP / (d2 * sqrt(d2))   # → force magnitude ∝ 1/d²
+                force[1, i] += dx * inv
+                force[2, i] += dy * inv
+                force[3, i] += dz * inv
+            end
+        end
+        # Parent-child springs (pull both endpoints together).
+        @inbounds for i in 2:n
+            p = _parent(tree, i)
+            dx = pos[1, p] - pos[1, i]
+            dy = pos[2, p] - pos[2, i]
+            dz = pos[3, p] - pos[3, i]
+            force[1, i] += _TREE_RELAX_SPRING * dx
+            force[2, i] += _TREE_RELAX_SPRING * dy
+            force[3, i] += _TREE_RELAX_SPRING * dz
+            force[1, p] -= _TREE_RELAX_SPRING * dx
+            force[2, p] -= _TREE_RELAX_SPRING * dy
+            force[3, p] -= _TREE_RELAX_SPRING * dz
+        end
+        # Cooling step, then project each node back onto its shell.
+        step = _TREE_RELAX_STEP0 * (1 - (it - 1) / _TREE_RELAX_ITERS)
+        @inbounds for i in 1:n
+            li = levels[i]
+            li == 0 && continue
+            x = pos[1, i] + step * force[1, i]
+            y = pos[2, i] + step * force[2, i]
+            z = pos[3, i] + step * force[3, i]
+            m = sqrt(x*x + y*y + z*z)
+            if m == 0
+                x, y, z, m = 1.0, 0.0, 0.0, 1.0
+            end
+            s = li / m
+            pos[1, i] = x * s
+            pos[2, i] = y * s
+            pos[3, i] = z * s
+        end
+    end
+    return pos
+end
+
+function _tree_positions_3d(tree::RegularTree)::Matrix{Float64}
+    R, n = tree.root_children, tree.n_nodes
+    pos = zeros(Float64, 3, n)            # root (node 1) stays at the origin
+    if tree.height >= 2
+        # Root's children seed the whole sphere (no parent direction to fan from),
+        # then each seeds a coherent cone for its own subtree.
+        dirs = _fibonacci_sphere(R)
+        cap0 = π / 2
+        @inbounds for m in 1:R
+            child = m + 1                 # root is node 1; its children are 2..R+1
+            u = _normalize3((dirs[1, m], dirs[2, m], dirs[3, m]))
+            _place_tree_node!(pos, tree, child, u, 1, cap0)
+        end
+    end
+    _relax_shells!(pos, _node_levels(tree), tree)
+    return pos
+end
+
 # =============================================================================
-# Factory Function
+# Factory Functions
 # =============================================================================
 
 """
-Create a regular rooted k-ary tree.
+Create a graph-theory **regular tree** (Cayley tree / Bethe lattice) of degree
+`degree` and `height` levels.
+
+Every internal vertex has degree `degree`: the root has `degree` children and
+every other internal node has `degree − 1` children (plus one parent). This is the
+canonical regular tree for percolation/branching-process analysis — the branching
+ratio is `degree − 1`.
+
+Note `degree = 2` is degenerate: the root has two children and every other
+internal node has a single child, so the tree is a **path** (two arms from the
+root). Use `degree ≥ 3` for a genuinely branching regular tree, or
+[`create_dary_tree`](@ref) for a balanced binary tree.
 
 # Arguments
-- `branching_factor::Int`: Children per internal node (`k ≥ 2`)
-- `height::Int`: Number of levels (`h ≥ 1`; `h = 1` = root only, `h = 2` = root + k leaves)
+- `degree::Int`: Degree of every internal vertex (`≥ 2`)
+- `height::Int`: Number of levels (`h ≥ 1`; `h = 1` = root only)
 
 # Returns
-- `RegularTree`: k-ary tree with `(kʰ − 1) ÷ (k − 1)` nodes
+- `RegularTree`: regular tree with root degree `degree`, internal branching `degree − 1`
 
 # Examples
 ```julia
-julia> create_regular_tree(2, 4)   # binary tree: 15 nodes, 4 levels
-julia> create_regular_tree(3, 3)   # ternary tree: 13 nodes, 3 levels
+julia> create_regular_tree(3, 4)   # degree-3 Cayley tree: root→3, then →2 each
+julia> create_regular_tree(4, 3)   # degree-4 Cayley tree
 ```
 """
-function create_regular_tree(branching_factor::Int, height::Int)::RegularTree
-    return RegularTree(branching_factor, height)
+function create_regular_tree(degree::Int, height::Int)::RegularTree
+    degree >= 2 || throw(ArgumentError("degree must be ≥ 2, got $degree"))
+    return RegularTree(degree, degree - 1, height)
+end
+
+"""
+Create a balanced **d-ary tree** (computer-science convention) with branching
+factor `branching` and `height` levels.
+
+Every internal node — the root included — has exactly `branching` children, so a
+non-root internal node has degree `branching + 1`. The tree has
+`(branchingʰ − 1) ÷ (branching − 1)` nodes.
+
+# Arguments
+- `branching::Int`: Children per internal node (`≥ 2`)
+- `height::Int`: Number of levels (`h ≥ 1`; `h = 1` = root only, `h = 2` = root + `branching` leaves)
+
+# Returns
+- `RegularTree`: balanced d-ary tree
+
+# Examples
+```julia
+julia> create_dary_tree(2, 4)   # binary tree: 15 nodes, 4 levels
+julia> create_dary_tree(3, 3)   # ternary tree: 13 nodes, 3 levels
+```
+"""
+function create_dary_tree(branching::Int, height::Int)::RegularTree
+    branching >= 2 || throw(ArgumentError("branching must be ≥ 2, got $branching"))
+    return RegularTree(branching, branching, height)
 end

--- a/src/graphs/star.jl
+++ b/src/graphs/star.jl
@@ -124,14 +124,23 @@ end
 # Geometry Interface (for visualization)
 # =============================================================================
 #
-# The center sits at the origin and the leaves are spread evenly on the unit
-# circle around it. It is not a space-filling tiling, so it supplies no cells.
+# The center sits at the origin and the leaves are spread evenly around it: on
+# the unit circle in 2D, on the unit sphere (Fibonacci spiral) in 3D. It is not a
+# space-filling tiling, so it supplies no cells.
 
-has_layout(::StarGraph)::Bool = true
-layout_dim(::StarGraph)::Int = 2
+supported_layout_dims(::StarGraph)::Tuple{Vararg{Int}} = (2, 3)
 
-function node_positions(graph::StarGraph)::Matrix{Float64}
+function node_positions(graph::StarGraph; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(graph, dim)
     n = graph.n_nodes
+    if dim == 3
+        # Center at the origin; leaves on the unit sphere.
+        pos = Matrix{Float64}(undef, 3, n)
+        @inbounds pos[:, 1] .= 0.0
+        leaves = _fibonacci_sphere(n - 1)
+        @inbounds pos[:, 2:n] .= leaves
+        return pos
+    end
     pos = Matrix{Float64}(undef, 2, n)
     @inbounds begin
         pos[1, 1] = 0.0

--- a/src/graphs/triangular_lattice.jl
+++ b/src/graphs/triangular_lattice.jl
@@ -148,8 +148,7 @@ end
 # equidistant at unit length. The dual cell is a regular hexagon centered on the
 # node, one edge crossing each of the 6 incident edges.
 
-has_layout(::TriangularLattice)::Bool = true
-layout_dim(::TriangularLattice)::Int = 2
+supported_layout_dims(::TriangularLattice)::Tuple{Vararg{Int}} = (2,)
 has_cells(::TriangularLattice)::Bool = true
 
 @inline function _tri_node_xy(row::Int, col::Int)::Tuple{Float64, Float64}
@@ -158,7 +157,8 @@ has_cells(::TriangularLattice)::Bool = true
     return (x, y)
 end
 
-function node_positions(lattice::TriangularLattice)::Matrix{Float64}
+function node_positions(lattice::TriangularLattice; dim::Int = 2)::Matrix{Float64}
+    _check_layout_dim(lattice, dim)
     n = lattice.n_nodes
     pos = Matrix{Float64}(undef, 2, n)
     @inbounds for idx in 1:n

--- a/src/visualization/network_viz.jl
+++ b/src/visualization/network_viz.jl
@@ -24,6 +24,10 @@ Static node-link visualizer for `AdjacencyGraph`.
 - `node_size::Float64`: Marker size for nodes
 - `show_edges::Bool`: Draw edges between nodes
 - `edge_color`: Color for edges
+- `dim::Int`: Drawing dimension, 2 or 3. With `dim = 3` the graph is laid out and
+  drawn in 3D (intrinsic 3D layout where the graph provides one — star, complete,
+  tree — otherwise a 3D force-directed layout). Lattices are 2D only and are not
+  drawn by this visualizer.
 """
 mutable struct NetworkVisualizer <: StaticVisualizer
     color_scheme::Symbol
@@ -31,16 +35,20 @@ mutable struct NetworkVisualizer <: StaticVisualizer
     node_size::Float64
     show_edges::Bool
     edge_color
+    dim::Int
 
     function NetworkVisualizer(;
                               color_scheme::Symbol = :general,
                               figure_size::Tuple{Int, Int} = (700, 700),
                               node_size::Real = 12.0,
                               show_edges::Bool = true,
-                              edge_color = (:gray, 0.5))
+                              edge_color = (:gray, 0.5),
+                              dim::Int = 2)
         color_scheme ∈ available_color_schemes() ||
             throw(ArgumentError("Unknown color scheme: $color_scheme"))
-        new(color_scheme, figure_size, Float64(node_size), show_edges, edge_color)
+        dim == 2 || dim == 3 ||
+            throw(ArgumentError("NetworkVisualizer dim must be 2 or 3, got $dim"))
+        new(color_scheme, figure_size, Float64(node_size), show_edges, edge_color, dim)
     end
 end
 
@@ -58,7 +66,8 @@ function get_visualization_settings(viz::NetworkVisualizer)::Dict{Symbol, Any}
         :color_scheme => viz.color_scheme,
         :figure_size => viz.figure_size,
         :node_size => viz.node_size,
-        :show_edges => viz.show_edges
+        :show_edges => viz.show_edges,
+        :dim => viz.dim
     )
 end
 

--- a/test/test_regular_tree.jl
+++ b/test/test_regular_tree.jl
@@ -2,13 +2,19 @@ using Test
 using GraphEpimodels
 using Random
 
-# Oracle: reference neighbor set for node i in a k-ary tree with n total nodes.
-function _tree_ref(k, n, i)
+# Oracle: reference neighbor set for node i in a tree whose root has `R` children
+# and whose other internal nodes have `b` children, with `n` total nodes (1-indexed
+# BFS order). Covers both conventions: d-ary uses R == b == k; the graph-theory
+# regular (Cayley) tree uses R == d, b == d - 1.
+function _tree_ref(R, b, n, i)
     neighbors = Int[]
-    i > 1 && push!(neighbors, (i - 2) ÷ k + 1)           # parent
-    first_child = k * (i - 1) + 2
+    if i > 1
+        push!(neighbors, i <= R + 1 ? 1 : 2 + (i - R - 2) ÷ b)   # parent
+    end
+    first_child = i == 1 ? 2 : R + 2 + (i - 2) * b
     if first_child <= n
-        append!(neighbors, first_child:min(k * i + 1, n)) # children
+        nc = i == 1 ? R : b
+        append!(neighbors, first_child:min(first_child + nc - 1, n))  # children
     end
     return neighbors
 end
@@ -22,94 +28,96 @@ end
 @testset "RegularTree" begin
 
     @testset "Construction and node count" begin
-        # n = (k^h - 1) ÷ (k - 1)
-        @test num_nodes(create_regular_tree(2, 1)) == 1
-        @test num_nodes(create_regular_tree(2, 2)) == 3
-        @test num_nodes(create_regular_tree(2, 3)) == 7
-        @test num_nodes(create_regular_tree(2, 4)) == 15
-        @test num_nodes(create_regular_tree(3, 1)) == 1
-        @test num_nodes(create_regular_tree(3, 2)) == 4
-        @test num_nodes(create_regular_tree(3, 3)) == 13
-        @test num_nodes(create_regular_tree(4, 3)) == 21
+        # d-ary: n = (k^h - 1) ÷ (k - 1)
+        @test num_nodes(create_dary_tree(2, 1)) == 1
+        @test num_nodes(create_dary_tree(2, 3)) == 7
+        @test num_nodes(create_dary_tree(2, 4)) == 15
+        @test num_nodes(create_dary_tree(3, 3)) == 13
+        @test num_nodes(create_dary_tree(4, 3)) == 21
 
-        t = create_regular_tree(2, 3)
+        # Cayley (graph-theory regular): root degree d, internal degree d.
+        @test num_nodes(create_regular_tree(2, 1)) == 1
+        @test [num_nodes(create_regular_tree(2, h)) for h in 1:4] == [1, 3, 5, 7]  # d=2 ⇒ path
+        @test [num_nodes(create_regular_tree(3, h)) for h in 1:4] == [1, 4, 10, 22]
+        @test num_nodes(create_regular_tree(4, 3)) == 17
+
+        # Shared struct, distinct child counts.
+        t = create_dary_tree(2, 3)
         @test t isa RegularTree
         @test t isa AbstractImplicitGraph
         @test !(t isa AbstractLatticeGraph)
-        @test t.branching_factor == 2
-        @test t.height == 3
+        @test t.root_children == 2 && t.branching == 2 && t.height == 3
 
-        @test_throws ArgumentError create_regular_tree(1, 3)   # k < 2
-        @test_throws ArgumentError create_regular_tree(0, 3)
-        @test_throws ArgumentError create_regular_tree(2, 0)   # h < 1
+        c = create_regular_tree(3, 3)
+        @test c.root_children == 3 && c.branching == 2
+
+        @test_throws ArgumentError create_dary_tree(1, 3)      # k < 2
+        @test_throws ArgumentError create_regular_tree(1, 3)   # d < 2
+        @test_throws ArgumentError create_dary_tree(2, 0)      # h < 1
+        @test_throws ArgumentError create_regular_tree(3, 0)   # h < 1
     end
 
-    @testset "Topology: binary tree (k=2, h=3, n=7)" begin
-        k, h = 2, 3
-        g = create_regular_tree(k, h)
-        n = num_nodes(g)
-        for i in 1:n
-            nb = get_neighbors(g, i)
-            ref = _tree_ref(k, n, i)
-            @test Set(nb) == Set(ref)
-            @test i ∉ nb                              # no self-loop
-            @test length(nb) == length(unique(nb))    # no duplicates
-        end
-        # Undirected: every edge is mirrored
-        for i in 1:n, j in get_neighbors(g, i)
-            @test i in get_neighbors(g, j)
-        end
-    end
-
-    @testset "Topology: ternary tree (k=3, h=3, n=13)" begin
-        k, h = 3, 3
-        g = create_regular_tree(k, h)
-        n = num_nodes(g)
-        for i in 1:n
-            @test Set(get_neighbors(g, i)) == Set(_tree_ref(k, n, i))
-        end
-        for i in 1:n, j in get_neighbors(g, i)
-            @test i in get_neighbors(g, j)
+    @testset "Topology vs oracle" begin
+        cases = [(create_dary_tree(2, 3),    2, 2),
+                 (create_dary_tree(3, 3),    3, 3),
+                 (create_regular_tree(3, 4), 3, 2),   # Cayley: R=3, b=2
+                 (create_regular_tree(4, 3), 4, 3),
+                 (create_regular_tree(2, 4), 2, 1)]   # Cayley path
+        for (g, R, b) in cases
+            n = num_nodes(g)
+            for i in 1:n
+                nb = get_neighbors(g, i)
+                @test Set(nb) == Set(_tree_ref(R, b, n, i))
+                @test i ∉ nb                              # no self-loop
+                @test length(nb) == length(unique(nb))    # no duplicates
+            end
+            for i in 1:n, j in get_neighbors(g, i)        # undirected: edges mirrored
+                @test i in get_neighbors(g, j)
+            end
         end
     end
 
     @testset "Degrees" begin
-        # Binary tree, h=3: root deg 2, internal (2,3) deg 3, leaves (4-7) deg 1
-        g = create_regular_tree(2, 3)
-        @test get_node_degree(g, 1) == 2   # root
-        @test get_node_degree(g, 2) == 3   # internal
-        @test get_node_degree(g, 3) == 3
-        @test get_node_degree(g, 4) == 1   # leaf
-        @test get_node_degree(g, 7) == 1
+        # d-ary binary tree, h=3: root deg 2, internal (2,3) deg 3, leaves deg 1.
+        g = create_dary_tree(2, 3)
+        @test get_node_degree(g, 1) == 2
+        @test get_node_degree(g, 2) == 3
+        @test get_node_degree(g, 4) == 1
 
-        # Degree matches actual neighbor count for all nodes
-        for k in [2, 3, 4], h in [1, 2, 3, 4]
-            tree = create_regular_tree(k, h)
-            n = num_nodes(tree)
-            for i in 1:n
+        # Cayley d=3: root degree 3, every internal vertex degree 3, leaves deg 1.
+        c = create_regular_tree(3, 3)
+        @test get_node_degree(c, 1) == 3
+        @test get_node_degree(c, 2) == 3            # 1 parent + 2 children
+        @test get_node_degree(c, num_nodes(c)) == 1 # leaf
+
+        # Degree matches actual neighbor count for all nodes, both conventions.
+        trees = vcat([create_dary_tree(k, h) for k in [2, 3, 4] for h in [1, 2, 3, 4]],
+                     [create_regular_tree(d, h) for d in [2, 3, 4] for h in [1, 2, 3, 4]])
+        for tree in trees
+            for i in 1:num_nodes(tree)
                 @test get_node_degree(tree, i) == length(get_neighbors(tree, i))
             end
         end
 
-        # Single-node tree (h=1): root has degree 0
-        solo = create_regular_tree(2, 1)
-        @test get_node_degree(solo, 1) == 0
-        @test isempty(get_neighbors(solo, 1))
+        # Single-node tree (h=1): root has degree 0.
+        for solo in (create_dary_tree(2, 1), create_regular_tree(3, 1))
+            @test get_node_degree(solo, 1) == 0
+            @test isempty(get_neighbors(solo, 1))
+        end
     end
 
     @testset "get_neighbors! buffer reuse" begin
-        g = create_regular_tree(2, 4)
+        g = create_dary_tree(2, 4)
         buf = Int[]
         for i in 1:num_nodes(g)
             result = get_neighbors!(buf, g, i)
             @test result === buf          # same buffer object returned
-            @test Set(buf) == Set(_tree_ref(2, num_nodes(g), i))
+            @test Set(buf) == Set(_tree_ref(2, 2, num_nodes(g), i))
         end
     end
 
     @testset "State counting oracle" begin
-        for (k, h) in [(2, 4), (3, 3)]
-            g = create_regular_tree(k, h)
+        for g in (create_dary_tree(2, 4), create_regular_tree(3, 4))
             n = num_nodes(g)
             rng = MersenneTwister(42)
             states = node_states_raw(g)
@@ -123,37 +131,43 @@ end
     end
 
     @testset "Geometry" begin
-        for (k, h) in [(2, 1), (2, 3), (3, 3)]
-            g = create_regular_tree(k, h)
+        # Both conventions, both layout dimensions: root at origin, every node on
+        # the shell of radius = its level.
+        cases = [create_dary_tree(2, 1), create_dary_tree(2, 3), create_dary_tree(3, 3),
+                 create_regular_tree(3, 3), create_regular_tree(4, 3), create_regular_tree(2, 4)]
+        for g in cases
             n = num_nodes(g)
             @test has_layout(g)
             @test layout_dim(g) == 2
+            @test supported_layout_dims(g) == (2, 3)
             @test !has_cells(g)
 
-            pos = node_positions(g)
-            @test size(pos) == (2, n)
+            R, b, h = g.root_children, g.branching, g.height
+            for dim in (2, 3)
+                pos = node_positions(g; dim = dim)
+                @test size(pos) == (dim, n)
+                @test all(iszero, @view pos[:, 1])           # root at origin
 
-            # Root at origin
-            @test pos[1, 1] ≈ 0.0 atol=1e-12
-            @test pos[2, 1] ≈ 0.0 atol=1e-12
-
-            # Level-l nodes lie on circle of radius l
-            node_idx = 1
-            for level in 0:(h - 1)
-                level_count = k^level
-                r = Float64(level)
-                for _ in 1:level_count
-                    dist = sqrt(pos[1, node_idx]^2 + pos[2, node_idx]^2)
-                    @test dist ≈ r atol=1e-12
-                    node_idx += 1
+                node_idx = 1
+                for level in 0:(h - 1)
+                    level_count = level == 0 ? 1 : R * b^(level - 1)
+                    for _ in 1:level_count
+                        @test sqrt(sum(abs2, @view pos[:, node_idx])) ≈ Float64(level) atol = 1e-9
+                        node_idx += 1
+                    end
                 end
             end
         end
+
+        # 2D rings are equidistant: all angular gaps within a level are equal.
+        p = node_positions(create_dary_tree(3, 3); dim = 2)
+        ang(i) = atan(p[2, i], p[1, i])
+        gaps = sort([mod(ang(i + 1) - ang(i), 2π) for i in 5:12])  # ternary level 2 = nodes 5..13
+        @test gaps[end] - gaps[1] < 1e-9
     end
 
     @testset "SIR conservation" begin
-        for (k, h) in [(2, 5), (3, 4)]
-            g = create_regular_tree(k, h)
+        for g in (create_dary_tree(2, 5), create_regular_tree(3, 4))
             p = SIRProcess(g, 3.0, 1.0)
             reset!(p, [1]; rng_seed = 1)
             steps = 0

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -72,10 +72,50 @@ sir_on(g) = create_sir_process(g, 0.6, 1.0; initial_infected = [1], rng_seed = 1
     end
 
     @testset "node_positions shape" begin
-        # Every graph type that reports a layout returns a 2 × N matrix.
+        # Every graph type that reports a layout returns a 2 × N matrix by default.
         for (_, g) in vcat(lattice_graphs(), network_graphs())
             has_layout(g) || continue
             @test size(node_positions(g)) == (2, num_nodes(g))
+        end
+    end
+
+    @testset "layout dimensions" begin
+        # Default (preferred) dim is 2 for every type that has a layout, so the
+        # 2D rendering path is unchanged.
+        for (_, g) in vcat(lattice_graphs(), network_graphs())
+            has_layout(g) || continue
+            @test layout_dim(g) == 2
+            @test 2 in supported_layout_dims(g)
+        end
+
+        # Lattices, cycle and path are planar-only: they advertise dim 2 only and
+        # reject a 3D request rather than returning wrong coordinates.
+        for (_, g) in vcat(lattice_graphs(),
+                           [("cycle", create_cycle_graph(8)), ("path", create_path_graph(5))])
+            @test supported_layout_dims(g) == (2,)
+            @test_throws ArgumentError node_positions(g; dim = 3)
+        end
+
+        # Star / complete / tree carry a closed-form 3D layout (3 × N). Both tree
+        # conventions advertise (2, 3); detailed tree geometry is checked in
+        # test_regular_tree.jl.
+        for (_, g) in [("star", create_star_graph(7)),
+                       ("complete", create_complete_graph(6)),
+                       ("dary-tree", create_dary_tree(2, 4)),
+                       ("regular-tree", create_regular_tree(3, 3))]
+            @test supported_layout_dims(g) == (2, 3)
+            p3 = node_positions(g; dim = 3)
+            @test size(p3) == (3, num_nodes(g))
+        end
+    end
+
+    @testset "3D layout geometry" begin
+        # Star: center at origin, every leaf on the unit sphere.
+        star = create_star_graph(9)
+        p = node_positions(star; dim = 3)
+        @test all(iszero, p[:, 1])
+        for i in 2:num_nodes(star)
+            @test isapprox(hypot(p[1, i], p[2, i], p[3, i]), 1.0; atol = 1e-9)
         end
     end
 
@@ -130,6 +170,33 @@ sir_on(g) = create_sir_process(g, 0.6, 1.0; initial_infected = [1], rng_seed = 1
                                    sampler = EveryStep(), max_steps = 20,
                                    filename = file, visualizer = NetworkVisualizer())
                 @test isfile(file) && filesize(file) > 0
+            end
+
+            # 3D node-link: static render + save (star sphere) and a turntable
+            # animation (tree shells), covering the Axis3 draw path end to end.
+            @testset "3D static render + save" begin
+                g = create_star_graph(8)
+                fig = render_frame(NetworkVisualizer(dim = 3), g, node_states_raw(g))
+                @test fig isa Figure
+                file = joinpath(dir, "star_3d.png")
+                save_plot(sir_on(g), file; dim = 3)
+                @test isfile(file) && filesize(file) > 0
+            end
+
+            @testset "3D turntable animation" begin
+                file = joinpath(dir, "tree_3d.gif")
+                rec = animate_simulation(sir_on(create_dary_tree(2, 4));
+                                         sampler = EveryStep(), max_steps = 20,
+                                         filename = file, dim = 3, turntable = true)
+                @test rec isa SimulationRecording
+                @test isfile(file) && filesize(file) > 0
+            end
+
+            # A lattice has no 3D layout: requesting dim=3 is a clear error, not a
+            # silently-wrong drawing.
+            @testset "lattice rejects dim=3" begin
+                @test_throws ArgumentError save_plot(sir_on(create_square_lattice(4, 4)),
+                                                     joinpath(dir, "nope.png"); dim = 3)
             end
         end
     end


### PR DESCRIPTION
## Summary

Adds 2D **and 3D** layout support to the visualization layer, and reworks `RegularTree` to offer both common rooted-tree degree conventions with subtree-coherent, evenly-spaced layouts.

Two logical commits:

1. **Add 2D/3D layout dimensions and static 3D visualization** — generalizes the geometry interface from a single canonical layout to a *set* of supported dimensions.
2. **RegularTree: graph-theory & d-ary conventions with coherent 3D layouts** — two tree conventions in one struct, plus the coherent/relaxed tree layouts.

## Geometry interface (commit 1)

- `supported_layout_dims(graph)` is the new capability query (e.g. `(2,)`, `(2, 3)`, or `()`); `has_layout` and `layout_dim` are derived from it.
- `node_positions(graph; dim)` produces the layout in 2 or 3 dimensions (`dim × N`, defaulting to the preferred dimension). Unsupported dims raise a clear error.
- Closed-form 3D layouts: **StarGraph** and **CompleteGraph** (even Fibonacci-sphere distribution). Lattices, cycle and path stay 2D-only.
- Graphs with no intrinsic 3D embedding (ER / bare adjacency) fall back to a 3D force-directed layout.

## Rendering (commit 1)

- `NetworkVisualizer` gained a `dim` field and draws node-link graphs in 3D via a Makie `Axis3`.
- `save_plot` / `animate_recording` / `animate_simulation` accept `dim=3`, plus a `turntable` option that rotates the camera one full turn over an animation. **No new dependencies** — all on the existing CairoMakie backend (GLMakie-based *interactive* 3D is tracked separately in #23).

## RegularTree conventions (commit 2)

`RegularTree` now covers both conventions in one shared struct:

- `create_regular_tree(d, h)` → **graph-theory regular tree** (Cayley / Bethe lattice): every internal vertex has degree `d`. This is the canonical regular tree for branching-process / percolation analysis.
- `create_dary_tree(k, h)` → **balanced d-ary tree** (every internal node has `k` children) — the previous behavior.

⚠️ **Behavior change:** `create_regular_tree` changed meaning (it was the balanced d-ary tree). Callers wanting the old behavior should switch to `create_dary_tree`. Note `create_regular_tree(2, h)` is a path under the new convention.

## Tree layouts (commit 2)

Both tree layouts are now subtree-coherent (children placed near their parent, edges fan outward):

- **2D**: each node sits at the center of its angular arc — rings stay equidistant while children straddle their parent.
- **3D**: a recursive cone-tree seed followed by a deterministic shell-constrained relaxation (pairwise repulsion + parent-child springs, each node projected onto its `radius = level` shell). This cut the minimum node spacing from near-overlap (~0.18) to roughly the shell gap (~1.0).

## Testing

- Full suite: **2206 pass** (up from 1688; the two tree conventions and 3D layouts added coverage).
- The CairoMakie rendering tier (3D static render, turntable animation, lattice-rejects-3D) was exercised locally via `GRAPHEPIMODELS_VIZ_RENDER=1`.

Closes nothing; follow-up #23 tracks interactive (GLMakie) 3D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
