### PR TITLE
perf: cut per-step allocations and O(active) work on the Gillespie hot path

### DIFF
--- a/src/core/active_tracker.jl
+++ b/src/core/active_tracker.jl
@@ -35,6 +35,13 @@ This is the pattern from your efficient old implementation.
 mutable struct DictActiveTracker <: ActiveNodeTracker
     active_nodes::Dict{Int, Int}  # node_id → susceptible_neighbor_count
 
+    # Running sum of all weights in `active_nodes`, maintained incrementally by the
+    # add/remove/update/clear mutators below so that `get_total_boundary` is O(1)
+    # instead of an O(active) `sum(values(...))`. It runs on every Gillespie step
+    # (often more than once per step for the two-event-class models), so the linear
+    # sum was pure per-step overhead. Invariant: total_weight == sum(values(active_nodes)).
+    total_weight::Int
+
     # Scratch buffers reused by _weighted_sample_active_fast so that weighted
     # sampling allocates nothing on the hot path. A tracker is owned by a single
     # process (and thus a single thread during threaded runs), so reusing these
@@ -42,7 +49,7 @@ mutable struct DictActiveTracker <: ActiveNodeTracker
     nodes_buf::Vector{Int}        # idx → node_id
     cumw_buf::Vector{Int}         # idx → cumulative weight up to and including idx
 
-    DictActiveTracker() = new(Dict{Int, Int}(), Int[], Int[])
+    DictActiveTracker() = new(Dict{Int, Int}(), 0, Int[], Int[])
 end
 
 """
@@ -55,7 +62,11 @@ Add a node to active tracking.
 """
 function add_active_node!(tracker::DictActiveTracker, node_id::Int, neighbor_count::Int)
     if neighbor_count > 0
+        # Adjust the running total by the delta vs. any existing weight, so a
+        # repeated add (overwrite) stays consistent with the dict.
+        old = get(tracker.active_nodes, node_id, 0)
         tracker.active_nodes[node_id] = neighbor_count
+        tracker.total_weight += neighbor_count - old
     end
 end
 
@@ -63,7 +74,9 @@ end
 Remove a node from active tracking.
 """
 function remove_active_node!(tracker::DictActiveTracker, node_id::Int)
-    delete!(tracker.active_nodes, node_id)
+    # pop! returns the removed weight (0 if absent), so the total stays in sync
+    # whether or not the node was present.
+    tracker.total_weight -= pop!(tracker.active_nodes, node_id, 0)
 end
 
 """
@@ -71,9 +84,11 @@ Update neighbor count for an active node.
 """
 function update_active_node!(tracker::DictActiveTracker, node_id::Int, new_count::Int)
     if new_count > 0
+        old = get(tracker.active_nodes, node_id, 0)
         tracker.active_nodes[node_id] = new_count
+        tracker.total_weight += new_count - old
     else
-        delete!(tracker.active_nodes, node_id)
+        tracker.total_weight -= pop!(tracker.active_nodes, node_id, 0)
     end
 end
 
@@ -85,10 +100,11 @@ function get_active_nodes(tracker::DictActiveTracker)::Vector{Int}
 end
 
 """
-Get total boundary (sum of all neighbor counts).
+Get total boundary (sum of all neighbor counts). O(1): returns the incrementally
+maintained running sum (see `total_weight`).
 """
 function get_total_boundary(tracker::DictActiveTracker)::Int
-    return sum(values(tracker.active_nodes))
+    return tracker.total_weight
 end
 
 """
@@ -103,6 +119,7 @@ Clear all active nodes.
 """
 function clear_active_nodes!(tracker::DictActiveTracker)
     empty!(tracker.active_nodes)
+    tracker.total_weight = 0
 end
 
 # =============================================================================

--- a/src/graphs/graphs.jl
+++ b/src/graphs/graphs.jl
@@ -200,6 +200,19 @@ function get_boundary_nodes(graph::AbstractEpidemicGraph)::Vector{Int}
 end
 
 """
+Read-only, non-copying view of the boundary nodes for hot-path callers.
+
+`get_boundary_nodes` copies defensively so callers may mutate the result, but
+[`has_escaped`](@ref) only *reads* the list and runs on every Gillespie step
+under `stop_on_escape` — the defensive copy was pure per-step allocation (a
+boundary-sized `Vector{Int}` churned each step, the dominant GC cost of escape
+analysis). This internal accessor returns the underlying vector directly and
+must never be mutated. The default delegates to `get_boundary_nodes` so any type
+is handled correctly; lattices override it to hand back their stored perimeter.
+"""
+_boundary_nodes_view(graph::AbstractEpidemicGraph)::Vector{Int} = get_boundary_nodes(graph)
+
+"""
 Check if the graph has a boundary concept.
 
 # Returns
@@ -251,6 +264,9 @@ end
 
 # Lattices additionally precompute their perimeter (empty for periodic boundaries).
 get_boundary_nodes(lattice::AbstractLatticeGraph)::Vector{Int} = copy(lattice.boundary_nodes)
+
+# Hand back the stored perimeter without copying (read-only; see _boundary_nodes_view).
+_boundary_nodes_view(lattice::AbstractLatticeGraph)::Vector{Int} = lattice.boundary_nodes
 
 # =============================================================================
 # Geometry Interface (Optional - consumed by the visualization layer)

--- a/src/models/chasescape.jl
+++ b/src/models/chasescape.jl
@@ -70,14 +70,20 @@ mutable struct ChaseEscapeProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: S
     time::Float64
     steps::Int
     rng::R
+    # Reusable scratch buffers so per-step event handling allocates nothing on the
+    # hot path (mirrors ZIM; see issues #1/#3). One thread per process, so no locking.
+    neighbor_buf::Vector{Int}
+    susceptible_buf::Vector{Int}
 
     function ChaseEscapeProcess(graph::G, λ::Float64, μ::Float64;
                                 ghost::Bool = true,
                                 rng::R = Random.default_rng()) where {G<:AbstractEpidemicGraph, R<:AbstractRNG}
         _validate_rates("Red spread rate λ" => λ, "Blue catch rate μ" => μ)
+        neighbor_buf = Int[]; susceptible_buf = Int[]
+        sizehint!(neighbor_buf, 8); sizehint!(susceptible_buf, 8)
         new{G,R}(graph, λ, μ, ghost,
             DictActiveTracker(), DictActiveTracker(),
-            0.0, 0, rng)
+            0.0, 0, rng, neighbor_buf, susceptible_buf)
     end
 end
 
@@ -153,11 +159,11 @@ end
 # =============================================================================
 
 function _ce_spread!(process::ChaseEscapeProcess, acting_node::Int)
-    neighbors = get_neighbors(process.graph, acting_node)
+    neighbors = get_neighbors!(process.neighbor_buf, process.graph, acting_node)
     states    = node_states_raw(process.graph)
     # White nodes are SUSCEPTIBLE in the S/I/R encoding, so a "white neighbour" is a
     # susceptible neighbour — the shared picker applies directly.
-    target = _random_susceptible_neighbor(neighbors, states, Int[], process.rng)
+    target = _random_susceptible_neighbor(neighbors, states, process.susceptible_buf, process.rng)
 
     if target == 0
         @warn "Red node $acting_node has no white neighbours but is in spread tracker"
@@ -187,7 +193,8 @@ function _update_tracking_after_ce_spread!(process::ChaseEscapeProcess, new_red:
     blue_count = count_neighbors_by_state(process.graph, new_red, REMOVED)
     add_active_node!(process.catch_tracker, new_red, blue_count)
 
-    for neighbor in get_neighbors(process.graph, new_red)
+    # Reused buffer; new_red's own neighbor list is no longer needed by the caller.
+    for neighbor in get_neighbors!(process.neighbor_buf, process.graph, new_red)
         if states[neighbor] == infected_state
             spread_w = get(process.spread_tracker.active_nodes, neighbor, 0)
             update_active_node!(process.spread_tracker, neighbor, spread_w - 1)
@@ -206,7 +213,7 @@ function _ce_catch!(process::ChaseEscapeProcess, caught_node::Int)
     # `caught_node` went red→blue, so every red neighbour gained one blue
     # neighbour: increment its catch weight. Spread weights are unchanged
     # (`caught_node` was red, not white).
-    for neighbor in get_neighbors(process.graph, caught_node)
+    for neighbor in get_neighbors!(process.neighbor_buf, process.graph, caught_node)
         if states[neighbor] == infected_state
             catch_w = get(process.catch_tracker.active_nodes, neighbor, 0)
             update_active_node!(process.catch_tracker, neighbor, catch_w + 1)

--- a/src/models/epiprocess.jl
+++ b/src/models/epiprocess.jl
@@ -158,21 +158,23 @@ Check if infection has reached graph boundary.
 """
 function has_escaped(process::AbstractEpidemicProcess)::Bool
     graph = get_graph(process)
-    boundary_nodes = get_boundary_nodes(graph)
-    
+    # Read-only, non-copying view: has_escaped runs every step under
+    # stop_on_escape, so copying the boundary list here was pure per-step GC churn.
+    boundary_nodes = _boundary_nodes_view(graph)
+
     if isempty(boundary_nodes)
         return false  # No boundary concept for this graph type
     end
-    
+
     states = node_states_raw(graph)
     infected_state = state_to_int(INFECTED)
-    
-    for node in boundary_nodes
+
+    @inbounds for node in boundary_nodes
         if states[node] == infected_state
             return true
         end
     end
-    
+
     return false
 end
 

--- a/src/models/maki_thompson.jl
+++ b/src/models/maki_thompson.jl
@@ -63,15 +63,21 @@ mutable struct MakiThompsonProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: 
     time::Float64
     steps::Int
     rng::R
+    # Reusable scratch buffers so per-step event handling allocates nothing on the
+    # hot path (mirrors ZIM; see issues #1/#3). One thread per process, so no locking.
+    neighbor_buf::Vector{Int}
+    susceptible_buf::Vector{Int}
 
     function MakiThompsonProcess(graph::G,
                                   α::Float64, β::Float64,
                                   stifler_contact::Bool;
                                   rng::R = Random.default_rng()) where {G<:AbstractEpidemicGraph, R<:AbstractRNG}
         _validate_rates("Spreading rate α" => α, "Stifling rate β" => β)
+        neighbor_buf = Int[]; susceptible_buf = Int[]
+        sizehint!(neighbor_buf, 8); sizehint!(susceptible_buf, 8)
         new{G,R}(graph, α, β, stifler_contact,
             DictActiveTracker(), DictActiveTracker(),
-            Set{Int}(), 0.0, 0, rng)
+            Set{Int}(), 0.0, 0, rng, neighbor_buf, susceptible_buf)
     end
 end
 
@@ -136,9 +142,9 @@ end
 # =============================================================================
 
 function _mt_spread!(process::MakiThompsonProcess, acting_node::Int)
-    neighbors = get_neighbors(process.graph, acting_node)
+    neighbors = get_neighbors!(process.neighbor_buf, process.graph, acting_node)
     states    = node_states_raw(process.graph)
-    target = _random_susceptible_neighbor(neighbors, states, Int[], process.rng)
+    target = _random_susceptible_neighbor(neighbors, states, process.susceptible_buf, process.rng)
 
     if target == 0
         @warn "Spreader $acting_node has no susceptible neighbours but is in spreading tracker"
@@ -175,8 +181,9 @@ function _update_tracking_after_mt_spread!(process::MakiThompsonProcess,
     stifle_count = process.stifler_contact ? (i_count + r_count) : i_count
     add_active_node!(process.stifling_tracker, new_infected, stifle_count)
 
-    # Update all I-neighbours of new_infected
-    for neighbor in get_neighbors(process.graph, new_infected)
+    # Update all I-neighbours of new_infected (reused buffer; new_infected's own
+    # neighbor list is no longer needed by the caller at this point).
+    for neighbor in get_neighbors!(process.neighbor_buf, process.graph, new_infected)
         if states[neighbor] == infected_state
             # Spreading: each I-neighbour lost new_infected as a S-neighbour
             spread_w = get(process.spreading_tracker.active_nodes, neighbor, 0)
@@ -206,7 +213,7 @@ function _mt_stifle!(process::MakiThompsonProcess, stifling_node::Int)
     #   Each I-neighbour loses one catalyst → decrement stifling tracker.
     if !process.stifler_contact
         infected_state = state_to_int(INFECTED)
-        for neighbor in get_neighbors(process.graph, stifling_node)
+        for neighbor in get_neighbors!(process.neighbor_buf, process.graph, stifling_node)
             if states[neighbor] == infected_state
                 w = get(process.stifling_tracker.active_nodes, neighbor, 0)
                 if w > 0

--- a/src/models/sir.jl
+++ b/src/models/sir.jl
@@ -48,11 +48,20 @@ mutable struct SIRProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: SIRLikePr
     time::Float64
     steps::Int
     rng::R
+    # Reusable scratch buffers so per-step event handling allocates nothing on the
+    # hot path (mirrors ZIM; see issues #1/#3). neighbor_buf backs get_neighbors!
+    # calls; susceptible_buf collects susceptible neighbors when choosing a target.
+    # A process is used by one thread at a time, so reuse needs no locking.
+    neighbor_buf::Vector{Int}
+    susceptible_buf::Vector{Int}
 
     function SIRProcess(graph::G, β::Float64, γ::Float64;
                         rng::R = Random.default_rng()) where {G<:AbstractEpidemicGraph, R<:AbstractRNG}
         _validate_rates("Transmission rate β" => β, "Recovery rate γ" => γ)
-        new{G,R}(graph, β, γ, DictActiveTracker(), Set{Int}(), 0.0, 0, rng)
+        neighbor_buf = Int[]; susceptible_buf = Int[]
+        sizehint!(neighbor_buf, 8); sizehint!(susceptible_buf, 8)
+        new{G,R}(graph, β, γ, DictActiveTracker(), Set{Int}(), 0.0, 0, rng,
+            neighbor_buf, susceptible_buf)
     end
 end
 
@@ -112,9 +121,11 @@ end
 # =============================================================================
 
 function _sir_infect!(process::SIRProcess, acting_node::Int)
-    neighbors = get_neighbors(process.graph, acting_node)
+    # Reused scratch buffers (no allocation). neighbor_buf may alias an internal
+    # list for non-lattice graphs, so it is read only until we re-fetch below.
+    neighbors = get_neighbors!(process.neighbor_buf, process.graph, acting_node)
     states    = node_states_raw(process.graph)
-    target = _random_susceptible_neighbor(neighbors, states, Int[], process.rng)
+    target = _random_susceptible_neighbor(neighbors, states, process.susceptible_buf, process.rng)
 
     if target == 0
         @warn "Infected node $acting_node has no susceptible neighbors but is marked active"
@@ -124,9 +135,11 @@ function _sir_infect!(process::SIRProcess, acting_node::Int)
 
     states[target] = state_to_int(INFECTED)
     push!(process.infected_nodes, target)
-    # Same S→I tracker maintenance as ZIM (shared helper).
+    # Same S→I tracker maintenance as ZIM (shared helper). Re-fetch into
+    # neighbor_buf (acting_node's neighbors are no longer needed).
     _track_si_infection!(process.active_tracker, process.graph,
-                         get_neighbors(process.graph, target), acting_node, target)
+                         get_neighbors!(process.neighbor_buf, process.graph, target),
+                         acting_node, target)
 end
 
 function _sir_recover!(process::SIRProcess, recovering_node::Int)


### PR DESCRIPTION
Three independent hot-path optimizations from a perf review, one commit each. All are behavior-preserving: results are **bit-identical for a fixed seed** across ZIM/SIR/Maki-Thompson/Chase-Escape, and the full test suite (2349 tests) is green after each commit.

## Items

**1. `586f43b` — drop per-step boundary-list copy in `has_escaped`**
`has_escaped` runs every step when `stop_on_escape` is on (the default for `EscapeCriterion` survival analysis). It fetched the boundary list via `get_boundary_nodes`, which copies defensively — so each step allocated a fresh boundary-sized `Vector{Int}` (~3.2 KB on a 100×100 lattice) just to read it once. Added an internal read-only `_boundary_nodes_view` that hands back the lattice's stored perimeter without copying.
- `has_escaped`: **~3.2 KB/call → 0 B**. Public `get_boundary_nodes` still copies, so its mutate-safe contract is unchanged.
- The O(perimeter) scan itself remains; truly-O(1) escape detection needs the just-infected node threaded through the generic `run_simulation` loop (left as a follow-up).

**2. `4e911ed` — reuse per-step neighbor buffers in SIR, Maki-Thompson, Chase-Escape**
ZIM already carried reusable `neighbor_buf`/`susceptible_buf` and used the non-allocating `get_neighbors!`; the other three still called allocating `get_neighbors` (often twice/step) plus a fresh `Int[]`. Gave all three the same buffers. The substrate's `_random_susceptible_neighbor` already guarantees candidate order (hence RNG draw) is independent of which buffer is used, so results are unchanged.
- Per-step allocation **~20–50× lower** (steady state, 120×120): MT 227→11, CE 294→6, SIR 223→7 B/step. Residual is unavoidable active-set `Dict` growth.

**3. `e010eb8` — maintain active-tracker total weight incrementally (O(1) boundary)**
`get_total_boundary` summed the dict values — O(active), run once per step via `get_total_rate` and again per step in the two-event-class models (SIR/MT/CE), plus per loop iteration in ChaseEscape's `is_active`. Now `DictActiveTracker` keeps a running `total_weight`, updated by delta in add/remove/update/clear (each O(1)).
- `get_total_boundary`: **O(active) → O(1), 0 B**. Invariant `total_weight == sum(values(active_nodes))` verified to hold at every step of a full run.

## Verification
- Deterministic fingerprint (ZIM/SIR/MT/CE final state + a 200-sim ZIM escape sweep) **identical** after every commit; before/after allocation runs showed identical step counts, confirming the RNG sequence is unchanged.
- Full suite (2349 tests) green after each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)