### PR TITLE
perf: remove redundant AdjacencyGraph.node_degrees field (benchmarked)

### DIFF
--- a/bench/adjacency_bench.jl
+++ b/bench/adjacency_bench.jl
@@ -1,0 +1,105 @@
+"""
+Benchmark for the `AdjacencyGraph` / `ErdosRenyiGraph` simulation hot path.
+
+`bench/hypercubic_bench.jl` only exercises the lattice (implicit, on-demand
+neighbours). This benchmark covers the *stored-adjacency* path instead, which is
+the one that reads `AdjacencyGraph.node_degrees` — see issue #29 (deciding
+whether that precomputed-degree field earns its keep).
+
+It reports, as the noise-resistant minimum over `TRIALS`:
+  1. `count_neighbors_by_state` swept over every node (the per-Gillespie-step hot
+     path for adjacency-backed graphs; this is the reader the field optimizes),
+  2. `get_node_degree` swept over every node (the off-hot-path reader),
+  3. a full seeded ZIM run on an Erdős–Rényi graph (end-to-end), with its total
+     allocation.
+
+The script uses only the public API (no reference to `node_degrees`), so the
+identical file runs against both the baseline (field present) and the candidate
+(field removed).
+
+Run:  julia --project=. bench/adjacency_bench.jl
+"""
+
+using GraphEpimodels
+using Random, Printf
+
+# Robust microbenchmark: report the MINIMUM elapsed time over `TRIALS` (filters
+# GC pauses and scheduler jitter that inflate single-shot timings).
+const TRIALS = 9
+
+# Fixed Erdős–Rényi graph: n nodes, mean degree ≈ MEANDEG. Seeded so the graph
+# (and therefore every run below) is identical across baseline/candidate.
+const N       = 20_000
+const MEANDEG = 8.0
+build_graph() = create_gnp(N, MEANDEG / (N - 1); rng = MersenneTwister(2024))
+
+function time_count(g, target, reps)
+    n = num_nodes(g)
+    best = Inf
+    for _ in 1:TRIALS
+        acc = 0
+        t = @elapsed for _ in 1:reps, i in 1:n
+            acc += count_neighbors_by_state(g, i, target)
+        end
+        acc < 0 && error("dead code eliminated")
+        best = min(best, t)
+    end
+    return best
+end
+
+function time_degree(g, reps)
+    n = num_nodes(g)
+    best = Inf
+    for _ in 1:TRIALS
+        acc = 0
+        t = @elapsed for _ in 1:reps, i in 1:n
+            acc += get_node_degree(g, i)
+        end
+        acc == 0 && error("dead code eliminated")
+        best = min(best, t)
+    end
+    return best
+end
+
+# Full seeded ZIM run on the ER graph. Seeds a fixed block of nodes (so the run is
+# large and reproducible) and goes to completion. ZIM is chosen because its death
+# handler re-counts neighbours, hammering count_neighbors_by_state.
+const SEEDS = collect(1:25)
+function time_zim(g)
+    best = Inf; steps = 0; bytes = 0
+    for _ in 1:TRIALS
+        p = create_zim_process(g, 3.0, 1.0; initial_infected = SEEDS, rng_seed = 7)
+        local s = 0
+        stats = @timed while is_active(p) && s < 5_000_000
+            step!(p); s += 1
+        end
+        best = min(best, stats.time); steps = s; bytes = stats.bytes
+    end
+    return best, steps, bytes
+end
+
+function main()
+    g = build_graph()
+    # Randomize states for the count sweep (mix of S/I/R).
+    Random.seed!(11)
+    set_node_states_raw!(g, rand(Int8.(0:2), num_nodes(g)))
+
+    println("="^70)
+    @printf "ErdosRenyi G(n=%d, mean_deg≈%.1f), min of %d trials\n" N MEANDEG TRIALS
+
+    reps = 200
+    time_count(g, SUSCEPTIBLE, 1); time_degree(g, 1)         # warmup
+    tc = time_count(g, SUSCEPTIBLE, reps)
+    td = time_degree(g, reps)
+    @printf "  count_neighbors_by_state  %.3f ms / sweep  (%d sweeps)\n" 1e3tc/reps reps
+    @printf "  get_node_degree           %.3f ms / sweep  (%d sweeps)\n" 1e3td/reps reps
+
+    # Fresh graph for the run (the count sweep left states dirty).
+    gz = build_graph()
+    time_zim(gz)                                              # warmup
+    t, steps, bytes = time_zim(gz)
+    @printf "  full ZIM run              %.1f ms  (%d steps)  alloc=%.3f MB  %.2f B/step\n" 1e3t steps bytes/2^20 bytes/max(steps,1)
+    println("="^70)
+end
+
+main()

--- a/src/graphs/adjacency.jl
+++ b/src/graphs/adjacency.jl
@@ -23,7 +23,6 @@ Uses primitive Int8 states for maximum performance and minimal memory usage.
 - `adjacency_list::Vector{Vector{Int}}`: Neighbor lists for each node
 - `n_nodes::Int`: Total number of nodes (pre-computed)
 - `states::Vector{Int8}`: Node states (primitive array)
-- `node_degrees::Vector{Int}`: Pre-computed node degrees (optional optimization)
 - `coords::Union{Matrix{Float64}, Nothing}`: Optional `dim × n` node coordinates
   for plotting (column `i` = position of node `i`). `nothing` means no layout,
   and the visualizer computes one (e.g. force-directed).
@@ -32,7 +31,6 @@ mutable struct AdjacencyGraph <: AbstractEpidemicGraph
     adjacency_list::Vector{Vector{Int}}
     n_nodes::Int
     states::Vector{Int8}
-    node_degrees::Vector{Int}  # Pre-computed for performance
     coords::Union{Matrix{Float64}, Nothing}
 
     function AdjacencyGraph(adjacency_list::Vector{Vector{Int}};
@@ -46,15 +44,12 @@ mutable struct AdjacencyGraph <: AbstractEpidemicGraph
         # Validate adjacency list structure
         _validate_adjacency_list(adjacency_list)
 
-        # Pre-compute node degrees for performance
-        node_degrees = [length(neighbors) for neighbors in adjacency_list]
-
         # Initialize all nodes as susceptible
         states = zeros(Int8, n)
 
         coords_mat = _validate_coords(coords, n)
 
-        new(adjacency_list, n, states, node_degrees, coords_mat)
+        new(adjacency_list, n, states, coords_mat)
     end
 end
 
@@ -97,7 +92,7 @@ end
     if node_id < 1 || node_id > graph.n_nodes
         throw(BoundsError("Node ID $node_id out of range [1, $(graph.n_nodes)]"))
     end
-    return graph.node_degrees[node_id]
+    return length(graph.adjacency_list[node_id])
 end
 
 function node_states_raw(graph::AdjacencyGraph)::Vector{Int8}
@@ -147,26 +142,24 @@ end
 # =============================================================================
 
 """
-Optimized neighbor counting for general graphs.
-Uses pre-computed degrees and direct array access for maximum performance.
+Optimized neighbor counting for general graphs. Fetches the stored neighbor list
+once and iterates it directly (the empty-list early-out reuses that same load).
 """
-function count_neighbors_by_state(graph::AdjacencyGraph, node_id::Int, 
+function count_neighbors_by_state(graph::AdjacencyGraph, node_id::Int,
                                  target_state::NodeState)::Int
-    if graph.node_degrees[node_id] == 0
-        return 0  # No neighbors
-    end
-    
     neighbors = graph.adjacency_list[node_id]
+    isempty(neighbors) && return 0  # No neighbors
+
     states = graph.states
     target_int = state_to_int(target_state)
-    
+
     count = 0
     @inbounds for neighbor in neighbors
         if states[neighbor] == target_int
             count += 1
         end
     end
-    
+
     return count
 end
 

--- a/src/graphs/erdos_renyi.jl
+++ b/src/graphs/erdos_renyi.jl
@@ -249,7 +249,7 @@ function create_erdos_renyi(n::Int;
             throw(ArgumentError("Edge probability p must be in [0, 1] (got $p)"))
         Float64(p) >= 1.0 && _warn_complete_fallback(n)
         graph = AdjacencyGraph(_erdos_renyi_gnp(n, Float64(p), rng))
-        realized_m = sum(graph.node_degrees) ÷ 2
+        realized_m = sum(length, graph.adjacency_list) ÷ 2
         return ErdosRenyiGraph(graph, :gnp, Float64(p), realized_m)
     else
         m >= 0 || throw(ArgumentError("Edge count m must be non-negative (got $m)"))


### PR DESCRIPTION
Resolves #29 — decides, with measurements, whether `AdjacencyGraph`'s precomputed `node_degrees` field earns its keep, and removes it.

## Background

`AdjacencyGraph` carried `node_degrees::Vector{Int}` ("Pre-computed for performance"), duplicating information already O(1)-available as `length(adjacency_list[i])`. It cost `8n` bytes and imposed a sync invariant (must track `adjacency_list`; safe only because the list is never mutated post-construction). #29 asked to settle the question with numbers rather than inspection, since this code path had **no** benchmark (`bench/hypercubic_bench.jl` is lattice-only).

## What changed

**`c5613dd` — add the benchmark (field still present).** New `bench/adjacency_bench.jl` sweeps `count_neighbors_by_state` and `get_node_degree` over every node of a seeded Erdős–Rényi graph, plus a full seeded ZIM run, reported as the min over trials. Public-API only, so the same file measures baseline and candidate. Committed before the removal so checking out this commit reproduces the field-present baseline.

**`f0af9f4` — remove the field.** Drop `node_degrees` + its construction; `get_node_degree` → `length(adjacency_list[node_id])`; `count_neighbors_by_state` fetches the neighbor list once with an `isempty` early-out; `ErdosRenyiGraph` realized-edge count → `sum(length, adjacency_list) ÷ 2`.

## Measurements (ER n=20000, mean degree 8, min of 9 trials)

| reader | baseline (field) | candidate (no field) | note |
|---|---|---|---|
| `count_neighbors_by_state` | 0.290 ms/sweep | 0.291 ms/sweep | **hot path — neutral** |
| `get_node_degree` | 0.002 ms/sweep | 0.014 ms/sweep | off hot path; ~0.7 ns/call |
| full ZIM run | 7851 ms | 7608 ms | neutral / slightly better |
| alloc/step | 29.36 B | 29.36 B | unchanged |

The per-step hot path is neutral: `count_neighbors_by_state` already loads `adjacency_list[node_id]` to iterate it, so the `isempty` early-out reuses that load, and the dropped `degree == 0` check almost never fired (ER graphs have no degree-0 nodes). The only regression — `get_node_degree` — is not on the simulation hot path (only re-exported and delegated by `ErdosRenyiGraph`) and is sub-nanosecond per call. Per #29's decision rule (*neutral-or-better → remove*), the field goes: **−8n bytes and one fewer sync invariant**.

## Reviewer notes

- Full test suite green (2349 tests), including the Erdős–Rényi tests that exercise the rewritten realized-edge count.
- The benchmark's full-ZIM-run line is dominated by the weighted-sampler sort on ER graphs (~296 µs/step), not by neighbor counting — so the micro-sweep is the discriminating signal, not the end-to-end run. (Separate, larger optimization opportunity.)
- To reproduce the A/B: run `bench/adjacency_bench.jl` at `c5613dd` (field present) vs `f0af9f4` (field removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)