### PR TITLE
perf: hot-path follow-ups (neighbor counts, sampler, SIR recovery, sweep I/O)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,9 +29,11 @@ ProgressMeter = "1"
 julia = "1.10"
 
 [extras]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CairoMakie", "Logging", "Test"]
+test = ["CairoMakie", "CSV", "DataFrames", "Logging", "Test"]

--- a/ext/GraphEpimodelsPersistenceExt.jl
+++ b/ext/GraphEpimodelsPersistenceExt.jl
@@ -15,6 +15,145 @@ module GraphEpimodelsPersistenceExt
 using GraphEpimodels
 using CSV, DataFrames
 
+# =============================================================================
+# Batched in-memory survival-result store (read once / write once)
+# =============================================================================
+#
+# `run_parameter_sweep` previously called the single-row `get_next_start_seed` and
+# `update_or_append_survival_result` once per parameter; each re-read (and the
+# latter re-wrote) the entire CSV and re-parsed every row's JSON config. The store
+# below collapses that to one read up front and one write at the end: rows live in
+# a DataFrame, and each existing row's reproducibility config string is parsed once
+# on load and cached, so per-parameter seed lookups and result records are pure
+# in-memory operations.
+
+"""
+In-memory survival-result store: the result `DataFrame` plus, parallel to its
+rows, the cached config string of each row (so matching is one string compare, not
+a JSON re-parse).
+"""
+mutable struct SurvivalStore
+    df::DataFrame
+    config_strings::Vector{String}
+end
+
+const _SURVIVAL_COLUMNS = (:parameter, :num_simulations, :num_survivals,
+                           :survival_probability, :std_error, :start_seed,
+                           :end_seed, :process_config)
+
+"""Empty result DataFrame with the canonical column names and types."""
+_empty_survival_df()::DataFrame = DataFrame(
+    parameter            = Float64[],
+    num_simulations      = Int[],
+    num_survivals        = Int[],
+    survival_probability = Float64[],
+    std_error            = Float64[],
+    start_seed           = Int[],
+    end_seed             = Int[],
+    process_config       = String[],
+)
+
+"""Reproducibility config string for an existing CSV row (parses its JSON once)."""
+_row_config_string(row)::String =
+    process_info_to_config_string(parse_process_info_json(String(row.process_config)))
+
+"""
+Load the survival-result store from `filename`, reading and parsing the file once.
+A missing file yields an empty store; a corrupt file raises before any expensive
+computation runs.
+"""
+function GraphEpimodels.load_survival_results(filename::String)::SurvivalStore
+    if !isfile(filename)
+        return SurvivalStore(_empty_survival_df(), String[])
+    end
+    local df
+    try
+        df = CSV.read(filename, DataFrame)
+    catch e
+        error("Failed to read CSV file '$filename'. Please verify the file is not corrupted before running expensive computations. Error: $e")
+    end
+    config_strings = [_row_config_string(row) for row in eachrow(df)]
+    return SurvivalStore(df, config_strings)
+end
+
+"""Index of the row matching `(process_info, parameter_value)`, or `0` if none."""
+function _find_match(store::SurvivalStore, parameter_value::Float64,
+                     process_info::Dict{String, Any})::Int
+    target = process_info_to_config_string(process_info)
+    @inbounds for i in eachindex(store.config_strings)
+        if store.config_strings[i] == target && store.df[i, :parameter] == parameter_value
+            return i
+        end
+    end
+    return 0
+end
+
+"""
+Next starting seed for `(process_info, parameter_value)` against the in-memory
+store: `end_seed + 1` of the matching row, or `1` for a fresh start. No I/O.
+"""
+function GraphEpimodels.next_start_seed(store::SurvivalStore, parameter_value::Float64,
+                                        process_info::Dict{String, Any})::Int
+    idx = _find_match(store, parameter_value, process_info)
+    return idx == 0 ? 1 : store.df[idx, :end_seed] + 1
+end
+
+"""
+Record a batch of new results into the in-memory store. If a row for
+`(process_info, parameter_value)` exists, fold in the cumulative statistics;
+otherwise append a new row. Returns `true` if an existing row was updated. No I/O —
+call [`save_survival_results`](@ref) once afterwards to persist.
+"""
+function GraphEpimodels.record_survival_result!(
+    store::SurvivalStore,
+    parameter_value::Float64,
+    num_simulations::Int,
+    num_survivals::Int,
+    survival_probability::Float64,
+    std_error::Float64,
+    start_seed::Int,
+    end_seed::Int,
+    process_info::Dict{String, Any}
+)::Bool
+    idx = _find_match(store, parameter_value, process_info)
+
+    if idx != 0
+        # Fold the new batch into the existing row's cumulative statistics.
+        cumulative_num_sims      = store.df[idx, :num_simulations] + num_simulations
+        cumulative_num_survivals = store.df[idx, :num_survivals] + num_survivals
+        cumulative_survival_prob = cumulative_num_survivals / cumulative_num_sims
+        cumulative_std_error     = sqrt(cumulative_survival_prob *
+                                        (1 - cumulative_survival_prob) / cumulative_num_sims)
+
+        store.df[idx, :num_simulations]      = cumulative_num_sims
+        store.df[idx, :num_survivals]        = cumulative_num_survivals
+        store.df[idx, :survival_probability] = cumulative_survival_prob
+        store.df[idx, :std_error]            = cumulative_std_error
+        store.df[idx, :end_seed]             = end_seed
+        # start_seed and process_config stay as originally recorded.
+        return true
+    end
+
+    push!(store.df, (
+        parameter            = parameter_value,
+        num_simulations      = num_simulations,
+        num_survivals        = num_survivals,
+        survival_probability = survival_probability,
+        std_error            = std_error,
+        start_seed           = start_seed,
+        end_seed             = end_seed,
+        process_config       = process_info_to_json(process_info),
+    ))
+    push!(store.config_strings, process_info_to_config_string(process_info))
+    return false
+end
+
+"""Write the accumulated store to `filename` in a single pass."""
+function GraphEpimodels.save_survival_results(store::SurvivalStore, filename::String)
+    CSV.write(filename, store.df)
+    return nothing
+end
+
 """
 Get the next starting seed for a parameter sweep continuation.
 

--- a/src/analysis/survival_analysis.jl
+++ b/src/analysis/survival_analysis.jl
@@ -286,47 +286,52 @@ function run_parameter_sweep(
     std_errors = Vector{Float64}(undef, n_params)
     num_sims_vec = Vector{Int}(undef, n_params)
     num_survivals_vec = Vector{Int}(undef, n_params)
-    
+
+    # Load any existing results once up front; per-parameter seed lookups and
+    # result records then run against this in-memory store, and the file is written
+    # once after the loop — instead of re-reading and rewriting the whole CSV (and
+    # re-parsing every row) on every parameter.
+    store = save_to !== nothing ? load_survival_results(save_to) : nothing
+
     for (i, param) in enumerate(parameter_values)
         factory = factory_generator(param)
-        
-        # Determine starting seed for this parameter
-        start_seed = if save_to !== nothing
+
+        # Determine starting seed for this parameter (and capture its config for the
+        # result record below).
+        process_info = nothing
+        start_seed = 1
+        if save_to !== nothing
             # Create sample process to extract configuration
             sample_process = factory()
             process_info = extract_process_info(sample_process)
             sample_process = nothing  # Allow garbage collection
-            
-            # Check CSV for existing results and determine continuation seed
-            get_next_start_seed(save_to, param, process_info)
-        else
-            # No CSV persistence - always start from seed 1
-            1
+
+            # In-memory continuation seed from the loaded store (no I/O).
+            start_seed = next_start_seed(store, param, process_info)
         end
 
         @info "Running parameter $i/$(length(parameter_values)): λ=$param, start seed=$start_seed"
-        
+
         # Run survival analysis
         results = estimate_survival_probability(
-            factory, initial_infected, criterion; 
-            start_seed=start_seed, 
+            factory, initial_infected, criterion;
+            start_seed=start_seed,
             kwargs...
         )
-        
+
         # Store results
         survival_probs[i] = results[:survival_probability]
         std_errors[i] = results[:survival_std_error]
         num_sims_vec[i] = results[:num_survivals] + results[:num_extinctions]
         num_survivals_vec[i] = results[:num_survivals]
-        
-        # Save to CSV if requested
-        if save_to !== nothing            
+
+        # Record into the in-memory store if persistence is requested.
+        if save_to !== nothing
             # Calculate end seed
             end_seed = start_seed + num_sims_vec[i] - 1
-            
-            # Update or append to CSV
-            was_updated = update_or_append_survival_result(
-                save_to,
+
+            was_updated = record_survival_result!(
+                store,
                 param,
                 num_sims_vec[i],
                 results[:num_survivals],
@@ -336,7 +341,7 @@ function run_parameter_sweep(
                 end_seed,
                 process_info
             )
-            
+
             if was_updated
                 @info "Parameter $param: Updated existing entry (seeds $start_seed-$end_seed)"
             else
@@ -344,7 +349,10 @@ function run_parameter_sweep(
             end
         end
     end
-    
+
+    # Persist all accumulated results in a single write.
+    save_to !== nothing && save_survival_results(store, save_to)
+
     return Dict{Symbol, Any}(
         :parameter_values => parameter_values,
         :num_simulations => num_sims_vec,

--- a/src/core/active_tracker.jl
+++ b/src/core/active_tracker.jl
@@ -42,14 +42,34 @@ mutable struct DictActiveTracker <: ActiveNodeTracker
     # sum was pure per-step overhead. Invariant: total_weight == sum(values(active_nodes)).
     total_weight::Int
 
-    # Scratch buffers reused by _weighted_sample_active so that weighted sampling
-    # allocates nothing on the hot path. A tracker is owned by a single process
-    # (and thus a single thread during threaded runs), so reusing these across
-    # calls is safe without any locking. See issues #1 / #3.
-    nodes_buf::Vector{Int}        # idx → node_id
+    # Active node ids held in ascending (canonical) order, maintained incrementally
+    # by the add/remove/update/clear mutators below. The weighted sampler reads this
+    # directly instead of collecting the Dict keys and `sort!`-ing them on every
+    # call, dropping the per-step sampling cost from O(active log active) to
+    # O(active) (the cumulative-weight pass) while keeping the same deterministic,
+    # order-independent selection. Invariant: `sorted_nodes` is exactly
+    # `sort(collect(keys(active_nodes)))`.
+    #
+    # `cumw_buf` is reused scratch for the cumulative-weight array so sampling still
+    # allocates nothing on the hot path. A tracker is owned by a single process (and
+    # thus a single thread during threaded runs), so reusing it across calls — and
+    # mutating `sorted_nodes` in place — is safe without any locking. See issues #1 / #3.
+    sorted_nodes::Vector{Int}     # active node ids, ascending (canonical order)
     cumw_buf::Vector{Int}         # idx → cumulative weight up to and including idx
 
     DictActiveTracker() = new(Dict{Int, Int}(), 0, Int[], Int[])
+end
+
+# Keep `sorted_nodes` canonical under membership changes. Both are O(active) in the
+# worst case (element shift), matching the cumulative-weight pass the sampler already
+# pays — so the sort's log factor is removed without adding a higher-order cost.
+@inline function _sorted_insert!(v::Vector{Int}, node_id::Int)
+    insert!(v, searchsortedfirst(v, node_id), node_id)
+end
+
+@inline function _sorted_delete!(v::Vector{Int}, node_id::Int)
+    # Caller guarantees node_id is present, so searchsortedfirst lands on it.
+    deleteat!(v, searchsortedfirst(v, node_id))
 end
 
 """
@@ -67,6 +87,7 @@ function add_active_node!(tracker::DictActiveTracker, node_id::Int, neighbor_cou
         old = get(tracker.active_nodes, node_id, 0)
         tracker.active_nodes[node_id] = neighbor_count
         tracker.total_weight += neighbor_count - old
+        old == 0 && _sorted_insert!(tracker.sorted_nodes, node_id)  # newly active
     end
 end
 
@@ -76,7 +97,9 @@ Remove a node from active tracking.
 function remove_active_node!(tracker::DictActiveTracker, node_id::Int)
     # pop! returns the removed weight (0 if absent), so the total stays in sync
     # whether or not the node was present.
-    tracker.total_weight -= pop!(tracker.active_nodes, node_id, 0)
+    removed = pop!(tracker.active_nodes, node_id, 0)
+    tracker.total_weight -= removed
+    removed > 0 && _sorted_delete!(tracker.sorted_nodes, node_id)  # was active
 end
 
 """
@@ -87,16 +110,19 @@ function update_active_node!(tracker::DictActiveTracker, node_id::Int, new_count
         old = get(tracker.active_nodes, node_id, 0)
         tracker.active_nodes[node_id] = new_count
         tracker.total_weight += new_count - old
+        old == 0 && _sorted_insert!(tracker.sorted_nodes, node_id)  # newly active
     else
-        tracker.total_weight -= pop!(tracker.active_nodes, node_id, 0)
+        removed = pop!(tracker.active_nodes, node_id, 0)
+        tracker.total_weight -= removed
+        removed > 0 && _sorted_delete!(tracker.sorted_nodes, node_id)  # dropped to inactive
     end
 end
 
 """
-Get all active nodes.
+Get all active nodes (a fresh copy, in ascending/canonical order).
 """
 function get_active_nodes(tracker::DictActiveTracker)::Vector{Int}
-    return collect(keys(tracker.active_nodes))
+    return copy(tracker.sorted_nodes)
 end
 
 """
@@ -119,6 +145,7 @@ Clear all active nodes.
 """
 function clear_active_nodes!(tracker::DictActiveTracker)
     empty!(tracker.active_nodes)
+    empty!(tracker.sorted_nodes)
     tracker.total_weight = 0
 end
 
@@ -131,14 +158,14 @@ Weighted sampler over the active set: selects a node with probability proportion
 to its susceptible-neighbor count. Critical for processes like ZIM where event
 rates depend on neighbor counts.
 
-Builds a cumulative-weight array and binary-searches it (`O(n)` to fill plus
-`O(log n)` to sample). Two properties matter:
+Builds a cumulative-weight array over the active set and binary-searches it
+(`O(active)` to fill plus `O(log active)` to sample). Two properties matter:
 
-1. **Allocation-free.** The node/cumulative-weight scratch arrays live on the
-   tracker and are resized in place, so this allocates nothing on the hot path.
-   It runs on every Gillespie step of every simulation; per-step heap allocation
-   here previously caused severe multithreaded GC pressure that serialized worker
-   threads (issues #1 and #3).
+1. **Allocation-free.** The canonical node array (`sorted_nodes`) and the
+   cumulative-weight scratch (`cumw_buf`) live on the tracker and are resized in
+   place, so this allocates nothing on the hot path. It runs on every Gillespie
+   step of every simulation; per-step heap allocation here previously caused severe
+   multithreaded GC pressure that serialized worker threads (issues #1 and #3).
 
 2. **Deterministic.** Nodes are sampled in a canonical order (ascending node id),
    NOT in `Dict` iteration order. A `Dict`'s iteration order depends on its
@@ -147,10 +174,12 @@ Builds a cumulative-weight array and binary-searches it (`O(n)` to fill plus
    simulations, or per-thread processes that each ran a different block of work —
    would otherwise map the same random draw onto different nodes. That made
    results depend on execution mode (serial vs. threaded) for a fixed seed.
-   Sorting by node id removes the dependence; QuickSort is in-place so this stays
-   allocation-free.
 
-The tracker is owned by a single process, so buffer reuse needs no locking.
+`sorted_nodes` is kept in ascending order incrementally by the tracker mutators,
+so this sampler no longer collects the Dict keys and `sort!`s them on every call —
+the per-step cost drops from O(active log active) to O(active) (just the cumulative
+pass) while the selection stays bit-identical. The tracker is owned by a single
+process, so reading/reusing its buffers needs no locking.
 
 # Arguments
 - `tracker::DictActiveTracker`: Active node tracker with neighbor counts
@@ -163,35 +192,20 @@ The tracker is owned by a single process, so buffer reuse needs no locking.
 - `ArgumentError`: If no active nodes available
 """
 function _weighted_sample_active(tracker::DictActiveTracker, rng::AbstractRNG)::Int
-    n_active = length(tracker.active_nodes)
+    nodes = tracker.sorted_nodes
+    n_active = length(nodes)
     if n_active == 0
         throw(ArgumentError("No active nodes to sample from"))
     end
 
     if n_active == 1
-        # first(d::Dict) returns a Pair{K,V}; .first extracts the key without
-        # allocating a KeySet wrapper (unlike first(keys(d))).
-        return first(tracker.active_nodes).first
+        return @inbounds nodes[1]
     end
 
-    # Reuse the tracker's scratch buffers instead of allocating fresh vectors.
-    nodes = tracker.nodes_buf
+    # `sorted_nodes` is already in canonical (ascending) order, so we only need to
+    # build cumulative weights over it — no per-call collect or sort.
     cumw = tracker.cumw_buf
-    resize!(nodes, n_active)
     resize!(cumw, n_active)
-
-    # Collect node ids, then sort into a canonical order so sampling does not
-    # depend on Dict iteration order (see the docstring). QuickSort is in-place.
-    # Iterate the Dict directly (not via keys()) to avoid allocating a KeySet
-    # wrapper object on every call — the actual 16 B/step found in issue #11.
-    i = 1
-    for (node_id, _) in tracker.active_nodes
-        nodes[i] = node_id
-        i += 1
-    end
-    sort!(nodes; alg = QuickSort)
-
-    # Build cumulative weights in canonical order.
     running = 0
     @inbounds for j in 1:n_active
         running += tracker.active_nodes[nodes[j]]

--- a/src/core/active_tracker.jl
+++ b/src/core/active_tracker.jl
@@ -42,10 +42,10 @@ mutable struct DictActiveTracker <: ActiveNodeTracker
     # sum was pure per-step overhead. Invariant: total_weight == sum(values(active_nodes)).
     total_weight::Int
 
-    # Scratch buffers reused by _weighted_sample_active_fast so that weighted
-    # sampling allocates nothing on the hot path. A tracker is owned by a single
-    # process (and thus a single thread during threaded runs), so reusing these
-    # across calls is safe without any locking. See issues #1 / #3.
+    # Scratch buffers reused by _weighted_sample_active so that weighted sampling
+    # allocates nothing on the hot path. A tracker is owned by a single process
+    # (and thus a single thread during threaded runs), so reusing these across
+    # calls is safe without any locking. See issues #1 / #3.
     nodes_buf::Vector{Int}        # idx → node_id
     cumw_buf::Vector{Int}         # idx → cumulative weight up to and including idx
 
@@ -127,42 +127,9 @@ end
 # =============================================================================
 
 """
-Weighted sampling from active nodes based on susceptible neighbor counts.
-
-Implements efficient weighted sampling where the probability of selecting a node
-is proportional to its number of susceptible neighbors. This is critical for
-processes like ZIM where event rates depend on neighbor counts.
-
-Uses the standard weighted sampling algorithm:
-1. Calculate cumulative weights
-2. Sample uniform random value in [0, total_weight]
-3. Binary search to find selected node
-
-# Arguments
-- `tracker::DictActiveTracker`: Active node tracker with neighbor counts
-- `rng::AbstractRNG`: Random number generator
-
-# Returns
-- `Int`: Selected node ID (weighted by neighbor count)
-
-# Throws
-- `ArgumentError`: If no active nodes available
-"""
-function _weighted_sample_active(tracker::DictActiveTracker, rng::AbstractRNG)::Int
-    n_active = length(tracker.active_nodes)
-    if n_active == 0
-        throw(ArgumentError("No active nodes to sample from"))
-    end
-
-    # Delegate to the single canonical (deterministic) sampler so that every
-    # active-set size goes through the same order-independent selection. The
-    # previous implementation walked the Dict directly, which made the chosen
-    # node depend on Dict iteration order — see _weighted_sample_active_fast.
-    return _weighted_sample_active_fast(tracker, n_active, rng)
-end
-
-"""
-Canonical weighted sampler over the active set, using the tracker's buffers.
+Weighted sampler over the active set: selects a node with probability proportional
+to its susceptible-neighbor count. Critical for processes like ZIM where event
+rates depend on neighbor counts.
 
 Builds a cumulative-weight array and binary-searches it (`O(n)` to fill plus
 `O(log n)` to sample). Two properties matter:
@@ -187,13 +154,16 @@ The tracker is owned by a single process, so buffer reuse needs no locking.
 
 # Arguments
 - `tracker::DictActiveTracker`: Active node tracker with neighbor counts
-- `n_active::Int`: Number of active nodes (length of `tracker.active_nodes`)
 - `rng::AbstractRNG`: Random number generator
 
 # Returns
 - `Int`: Selected node ID (weighted by neighbor count)
+
+# Throws
+- `ArgumentError`: If no active nodes available
 """
-function _weighted_sample_active_fast(tracker::DictActiveTracker, n_active::Int, rng::AbstractRNG)::Int
+function _weighted_sample_active(tracker::DictActiveTracker, rng::AbstractRNG)::Int
+    n_active = length(tracker.active_nodes)
     if n_active == 0
         throw(ArgumentError("No active nodes to sample from"))
     end

--- a/src/core/persistence.jl
+++ b/src/core/persistence.jl
@@ -271,6 +271,25 @@ get_next_start_seed(args...; kwargs...) =
 update_or_append_survival_result(args...; kwargs...) =
     error("update_or_append_survival_result $_CSV_HINT")
 
+# Batched in-memory survival-result store used by `run_parameter_sweep`. The
+# single-row `get_next_start_seed` / `update_or_append_survival_result` above each
+# re-read (and re-parse) the whole CSV — and the latter rewrites it — *per
+# parameter*, so a P-parameter sweep does O(P) reads + O(P) full rewrites and
+# re-parses every existing row O(P) times. These four functions instead load the
+# file once (`load_survival_results`), answer seed lookups and record results
+# against the in-memory store (`next_start_seed`, `record_survival_result!`), and
+# write the file once at the end (`save_survival_results`). Implemented in the
+# persistence extension; unexported (internal sweep machinery). The single-row
+# public functions are kept for direct/ad-hoc use.
+load_survival_results(args...; kwargs...) =
+    error("load_survival_results $_CSV_HINT")
+next_start_seed(args...; kwargs...) =
+    error("next_start_seed $_CSV_HINT")
+record_survival_result!(args...; kwargs...) =
+    error("record_survival_result! $_CSV_HINT")
+save_survival_results(args...; kwargs...) =
+    error("save_survival_results $_CSV_HINT")
+
 # =============================================================================
 # Exports
 # =============================================================================

--- a/src/graphs/hexagonal_lattice.jl
+++ b/src/graphs/hexagonal_lattice.jl
@@ -116,6 +116,46 @@ end
 end
 
 # =============================================================================
+# Performance-Optimized Neighbor Counting (simulation hot path)
+# =============================================================================
+
+"""
+Count a node's neighbours in `target_state` without materializing a neighbour
+list. Mirrors [`get_neighbors!`](@ref): walk the up-to-3 neighbours, testing the
+contiguous `Int8` state array directly. This is the inner loop of the SIR/ZIM
+steppers.
+"""
+function count_neighbors_by_state(lattice::HexagonalLattice, node_id::Int,
+                                  target_state::NodeState)::Int
+    _check_node(lattice, node_id)
+    row, col = _hex_index_to_coord(node_id, lattice.width)
+    target_int = state_to_int(target_state)
+    cnt = 0
+
+    # Two horizontal neighbors (same row).
+    cnt += _count_hex_neighbor(row, col - 1, lattice, target_int)
+    cnt += _count_hex_neighbor(row, col + 1, lattice, target_int)
+
+    # One vertical neighbor, direction set by parity of (row + col).
+    if iseven(row + col)
+        cnt += _count_hex_neighbor(row + 1, col, lattice, target_int)  # down
+    else
+        cnt += _count_hex_neighbor(row - 1, col, lattice, target_int)  # up
+    end
+
+    return cnt
+end
+
+"""Return 1 if neighbor (row, col) is in bounds and in `target_int`, else 0."""
+@inline function _count_hex_neighbor(row::Int, col::Int,
+                                     lattice::HexagonalLattice, target_int::Int8)::Int
+    if 1 <= row <= lattice.height && 1 <= col <= lattice.width
+        @inbounds return lattice.states[_hex_coord_to_index(row, col, lattice.width)] == target_int
+    end
+    return 0
+end
+
+# =============================================================================
 # Geometry Interface (for visualization)
 # =============================================================================
 #

--- a/src/graphs/regular_tree.jl
+++ b/src/graphs/regular_tree.jl
@@ -137,6 +137,43 @@ end
 end
 
 # =============================================================================
+# Performance-Optimized Neighbor Counting (simulation hot path)
+# =============================================================================
+
+"""
+Count a node's neighbours in `target_state` without materializing a neighbour
+list. Mirrors [`get_neighbors!`](@ref): test the parent (if any) and the
+contiguous block of children directly against the `Int8` state array. This is the
+inner loop of the SIR/ZIM steppers.
+"""
+function count_neighbors_by_state(tree::RegularTree, node_id::Int,
+                                  target_state::NodeState)::Int
+    _check_node(tree, node_id)
+    n = tree.n_nodes
+    states = tree.states
+    target_int = state_to_int(target_state)
+    cnt = 0
+
+    @inbounds begin
+        # Parent: every node except the root has one.
+        if node_id > 1 && states[_parent(tree, node_id)] == target_int
+            cnt += 1
+        end
+
+        # Children: a contiguous block in BFS order.
+        first_child = _first_child(tree, node_id)
+        if first_child <= n
+            last_child = min(first_child + _num_children(tree, node_id) - 1, n)
+            for c in first_child:last_child
+                cnt += states[c] == target_int
+            end
+        end
+    end
+
+    return cnt
+end
+
+# =============================================================================
 # Geometry Interface (for visualization)
 # =============================================================================
 #

--- a/src/graphs/triangular_lattice.jl
+++ b/src/graphs/triangular_lattice.jl
@@ -122,6 +122,52 @@ end
 end
 
 # =============================================================================
+# Performance-Optimized Neighbor Counting (simulation hot path)
+# =============================================================================
+
+"""
+Count a node's neighbours in `target_state` without materializing a neighbour
+list. Mirrors [`get_neighbors!`](@ref): walk the up-to-6 axis/diagonal neighbours,
+testing the contiguous `Int8` state array directly. This is the inner loop of the
+SIR/ZIM steppers.
+"""
+function count_neighbors_by_state(lattice::TriangularLattice, node_id::Int,
+                                  target_state::NodeState)::Int
+    _check_node(lattice, node_id)
+    row, col = _tri_index_to_coord(node_id, lattice.width)
+    target_int = state_to_int(target_state)
+    cnt = 0
+
+    # Two horizontal neighbors (same row).
+    cnt += _count_perimeter_neighbor(row, col - 1, lattice, target_int)
+    cnt += _count_perimeter_neighbor(row, col + 1, lattice, target_int)
+
+    # Four diagonal neighbors; column offsets depend on row parity.
+    if iseven(row)
+        cnt += _count_perimeter_neighbor(row - 1, col,     lattice, target_int)
+        cnt += _count_perimeter_neighbor(row - 1, col + 1, lattice, target_int)
+        cnt += _count_perimeter_neighbor(row + 1, col,     lattice, target_int)
+        cnt += _count_perimeter_neighbor(row + 1, col + 1, lattice, target_int)
+    else
+        cnt += _count_perimeter_neighbor(row - 1, col - 1, lattice, target_int)
+        cnt += _count_perimeter_neighbor(row - 1, col,     lattice, target_int)
+        cnt += _count_perimeter_neighbor(row + 1, col - 1, lattice, target_int)
+        cnt += _count_perimeter_neighbor(row + 1, col,     lattice, target_int)
+    end
+
+    return cnt
+end
+
+"""Return 1 if neighbor (row, col) is in bounds and in `target_int`, else 0."""
+@inline function _count_perimeter_neighbor(row::Int, col::Int,
+                                           lattice::TriangularLattice, target_int::Int8)::Int
+    if 1 <= row <= lattice.height && 1 <= col <= lattice.width
+        @inbounds return lattice.states[_tri_coord_to_index(row, col, lattice.width)] == target_int
+    end
+    return 0
+end
+
+# =============================================================================
 # Geometry Interface (for visualization)
 # =============================================================================
 #

--- a/src/models/sir.jl
+++ b/src/models/sir.jl
@@ -23,15 +23,17 @@ Uses a two-component rate structure:
 - Recovery events: total rate γ × (number of infected nodes)
 
 Active node tracking (`DictActiveTracker`) is used for infection events only
-(weighted by susceptible neighbor count). A separate `Set{Int}` tracks all
-infected nodes for O(1)-per-step recovery sampling.
+(weighted by susceptible neighbor count). Recovery is uniform over *all* infected
+nodes, so a dense `Vector{Int}` of infected node ids (with a `node → index` map)
+tracks them for O(1) recovery sampling and O(1) swap-removal.
 
 # Fields
 - `graph::AbstractEpidemicGraph`: The underlying graph
 - `β::Float64`: Transmission rate per infectious contact
 - `γ::Float64`: Recovery rate
 - `active_tracker::DictActiveTracker`: Infected nodes with susceptible neighbors
-- `infected_nodes::Set{Int}`: All currently infected nodes
+- `infected_nodes::Vector{Int}`: All currently infected nodes (dense, unordered)
+- `infected_index::Dict{Int,Int}`: node_id → its position in `infected_nodes`
 - `time::Float64`: Current simulation time
 - `steps::Int`: Number of steps executed
 - `rng::AbstractRNG`: Random number generator
@@ -44,7 +46,12 @@ mutable struct SIRProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: SIRLikePr
     β::Float64
     γ::Float64
     active_tracker::DictActiveTracker
-    infected_nodes::Set{Int}
+    # Recovery picks a uniformly random infected node. A dense Vector gives O(1)
+    # index sampling, and the parallel node→index map turns removal into an O(1)
+    # swap-with-last (vs. the previous Set, whose only random access was an
+    # O(#infected) iteration walk to the k-th element — linear per recovery step).
+    infected_nodes::Vector{Int}
+    infected_index::Dict{Int, Int}
     time::Float64
     steps::Int
     rng::R
@@ -60,7 +67,7 @@ mutable struct SIRProcess{G<:AbstractEpidemicGraph, R<:AbstractRNG} <: SIRLikePr
         _validate_rates("Transmission rate β" => β, "Recovery rate γ" => γ)
         neighbor_buf = Int[]; susceptible_buf = Int[]
         sizehint!(neighbor_buf, 8); sizehint!(susceptible_buf, 8)
-        new{G,R}(graph, β, γ, DictActiveTracker(), Set{Int}(), 0.0, 0, rng,
+        new{G,R}(graph, β, γ, DictActiveTracker(), Int[], Dict{Int, Int}(), 0.0, 0, rng,
             neighbor_buf, susceptible_buf)
     end
 end
@@ -94,6 +101,31 @@ end
 function _clear_trackers!(process::SIRProcess)
     clear_active_nodes!(process.active_tracker)
     empty!(process.infected_nodes)
+    empty!(process.infected_index)
+end
+
+# =============================================================================
+# Infected-set maintenance (dense Vector + node→index map)
+# =============================================================================
+
+"""Append a newly infected node, recording its position for O(1) swap-removal."""
+@inline function _add_infected!(process::SIRProcess, node_id::Int)
+    push!(process.infected_nodes, node_id)
+    process.infected_index[node_id] = length(process.infected_nodes)
+end
+
+"""
+Remove a recovered node in O(1) by swapping the last infected node into its slot
+(keeping `infected_nodes` and `infected_index` consistent).
+"""
+@inline function _remove_infected!(process::SIRProcess, node_id::Int)
+    nodes = process.infected_nodes
+    idx = process.infected_index[node_id]
+    last_node = nodes[end]
+    @inbounds nodes[idx] = last_node
+    process.infected_index[last_node] = idx
+    pop!(nodes)
+    delete!(process.infected_index, node_id)
 end
 
 function reset!(process::SIRProcess,
@@ -108,7 +140,7 @@ function reset!(process::SIRProcess,
     infected_state = state_to_int(INFECTED)
     for node_id in initial_infected
         states[node_id] = infected_state
-        push!(process.infected_nodes, node_id)
+        _add_infected!(process, node_id)
     end
     for node_id in initial_infected
         susceptible_count = count_neighbors_by_state(process.graph, node_id, SUSCEPTIBLE)
@@ -134,7 +166,7 @@ function _sir_infect!(process::SIRProcess, acting_node::Int)
     end
 
     states[target] = state_to_int(INFECTED)
-    push!(process.infected_nodes, target)
+    _add_infected!(process, target)
     # Same S→I tracker maintenance as ZIM (shared helper). Re-fetch into
     # neighbor_buf (acting_node's neighbors are no longer needed).
     _track_si_infection!(process.active_tracker, process.graph,
@@ -146,7 +178,7 @@ function _sir_recover!(process::SIRProcess, recovering_node::Int)
     states = node_states_raw(process.graph)
     states[recovering_node] = state_to_int(REMOVED)
 
-    delete!(process.infected_nodes, recovering_node)
+    _remove_infected!(process, recovering_node)
     remove_active_node!(process.active_tracker, recovering_node)
     # Recovery I→R does not change any neighbor's susceptible-neighbor count,
     # so no active_tracker updates are needed for other nodes.
@@ -158,15 +190,7 @@ end
 
 function _sample_infected_uniform(process::SIRProcess)::Int
     n = length(process.infected_nodes)
-    target_idx = rand(process.rng, 1:n)
-    i = 0
-    for node in process.infected_nodes
-        i += 1
-        if i == target_idx
-            return node
-        end
-    end
-    return first(process.infected_nodes)
+    return @inbounds process.infected_nodes[rand(process.rng, 1:n)]
 end
 
 # =============================================================================

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,5 @@ using Random
     include("test_structured_graphs.jl")
     include("test_regular_tree.jl")
     include("test_visualization.jl")
+    include("test_persistence.jl")
 end

--- a/test/test_lattices.jl
+++ b/test/test_lattices.jl
@@ -301,10 +301,9 @@ end
     GraphEpimodels.remove_active_node!(t2, 1000)
 
     @test t1.active_nodes == t2.active_nodes  # equal contents...
-    n = length(pairs)
     for seed in 1:100
-        a = GraphEpimodels._weighted_sample_active_fast(t1, n, MersenneTwister(seed))
-        b = GraphEpimodels._weighted_sample_active_fast(t2, n, MersenneTwister(seed))
+        a = GraphEpimodels._weighted_sample_active(t1, MersenneTwister(seed))
+        b = GraphEpimodels._weighted_sample_active(t2, MersenneTwister(seed))
         @test a == b  # ...therefore identical selection for the same draw
     end
 end

--- a/test/test_lattices.jl
+++ b/test/test_lattices.jl
@@ -307,3 +307,39 @@ end
         @test a == b  # ...therefore identical selection for the same draw
     end
 end
+
+# The sampler no longer sorts per call: it reads `sorted_nodes`, which the
+# add/update/remove mutators must keep equal to sort(collect(keys(active_nodes)))
+# at all times. A drifted invariant would silently corrupt weighted selection, so
+# check it directly under a churn of every mutator path (insert, weight-only
+# update, update-to-zero removal, explicit removal, re-insert, overwrite).
+@testset "active tracker maintains sorted_nodes invariant" begin
+    t = GraphEpimodels.DictActiveTracker()
+    canonical(tr) = sort(collect(keys(tr.active_nodes)))
+    @test t.sorted_nodes == canonical(t)
+
+    GraphEpimodels.add_active_node!(t, 50, 2)
+    GraphEpimodels.add_active_node!(t, 10, 1)
+    GraphEpimodels.add_active_node!(t, 30, 3)
+    GraphEpimodels.add_active_node!(t, 20, 1)
+    @test t.sorted_nodes == canonical(t) == [10, 20, 30, 50]
+
+    GraphEpimodels.update_active_node!(t, 30, 5)   # weight-only: order unchanged
+    @test t.sorted_nodes == canonical(t) == [10, 20, 30, 50]
+
+    GraphEpimodels.add_active_node!(t, 50, 4)       # overwrite existing: no dup insert
+    @test t.sorted_nodes == canonical(t) == [10, 20, 30, 50]
+
+    GraphEpimodels.update_active_node!(t, 20, 0)    # drop to inactive via update
+    @test t.sorted_nodes == canonical(t) == [10, 30, 50]
+
+    GraphEpimodels.remove_active_node!(t, 10)       # explicit removal
+    GraphEpimodels.remove_active_node!(t, 999)      # absent: no-op, stays consistent
+    @test t.sorted_nodes == canonical(t) == [30, 50]
+
+    GraphEpimodels.update_active_node!(t, 5, 2)     # newly active via update inserts in order
+    @test t.sorted_nodes == canonical(t) == [5, 30, 50]
+
+    GraphEpimodels.clear_active_nodes!(t)
+    @test isempty(t.sorted_nodes) && isempty(t.active_nodes)
+end

--- a/test/test_lattices.jl
+++ b/test/test_lattices.jl
@@ -343,3 +343,35 @@ end
     GraphEpimodels.clear_active_nodes!(t)
     @test isempty(t.sorted_nodes) && isempty(t.active_nodes)
 end
+
+# SIR recovery now samples from a dense Vector with O(1) swap-removal, backed by a
+# node→index map. A stale index would not necessarily crash (indices can stay
+# in-range), so check the bookkeeping invariant directly across a full run: the
+# infected vector has no duplicates, its index map points each node to its own
+# slot, and together they exactly equal the graph's INFECTED nodes.
+@testset "SIR infected-set swap-remove bookkeeping invariant" begin
+    g = create_square_lattice(25, 25, :absorbing)
+    p = SIRProcess(g, 3.0, 1.0)
+    reset!(p, [num_nodes(g) ÷ 2]; rng_seed = 7)
+
+    function _infected_consistent(p)
+        nodes = p.infected_nodes
+        idx = p.infected_index
+        length(nodes) == length(idx) || return false
+        for (i, nd) in enumerate(nodes)
+            get(idx, nd, 0) == i || return false
+        end
+        # The dense set must match the graph's actual INFECTED nodes exactly.
+        Set(nodes) == Set(get_nodes_in_state(g, INFECTED))
+    end
+
+    @test _infected_consistent(p)
+    steps = 0
+    ok = true
+    while is_active(p) && steps < 200_000
+        step!(p); steps += 1
+        ok &= _infected_consistent(p)
+    end
+    @test ok
+    @test isempty(p.infected_nodes) && isempty(p.infected_index)  # ran to extinction
+end

--- a/test/test_persistence.jl
+++ b/test/test_persistence.jl
@@ -1,0 +1,113 @@
+using Test
+using GraphEpimodels
+
+# Loading CSV + DataFrames activates GraphEpimodelsPersistenceExt, which provides
+# both the single-row public functions and the batched in-memory store that
+# run_parameter_sweep now uses (read once up front, write once at the end).
+using CSV, DataFrames
+
+# Shorthand for the unexported batched-store API.
+const GE = GraphEpimodels
+
+@testset "CSV survival-result persistence" begin
+
+    # Two distinct process configs and their reproducibility info dicts.
+    info_a = extract_process_info(create_zim_process(10, 10, 1.5))
+    info_b = extract_process_info(create_zim_process(10, 10, 2.5))
+
+    @testset "batched store: load / lookup / record / save" begin
+        mktempdir() do dir
+            csv = joinpath(dir, "results.csv")
+
+            # Missing file → empty store, fresh seed.
+            store = GE.load_survival_results(csv)
+            @test nrow(store.df) == 0
+            @test GE.next_start_seed(store, 1.5, info_a) == 1
+
+            # First record for (info_a, λ=1.5) appends a new row.
+            appended = GE.record_survival_result!(store, 1.5, 100, 40, 0.40,
+                                                  0.049, 1, 100, info_a)
+            @test appended == false
+            @test nrow(store.df) == 1
+            # Continuation seed now picks up after end_seed.
+            @test GE.next_start_seed(store, 1.5, info_a) == 101
+
+            # Same (config, param) → cumulative update of the existing row.
+            updated = GE.record_survival_result!(store, 1.5, 100, 60, 0.60,
+                                                 0.049, 101, 200, info_a)
+            @test updated == true
+            @test nrow(store.df) == 1
+            row = store.df[1, :]
+            @test row.num_simulations == 200          # 100 + 100
+            @test row.num_survivals == 100            # 40 + 60
+            @test row.survival_probability ≈ 0.5      # 100/200
+            @test row.start_seed == 1                 # unchanged
+            @test row.end_seed == 200
+            @test GE.next_start_seed(store, 1.5, info_a) == 201
+
+            # A different config (info_b) is independent → appends, fresh seed.
+            @test GE.next_start_seed(store, 1.5, info_b) == 1
+            GE.record_survival_result!(store, 1.5, 50, 10, 0.20, 0.057, 1, 50, info_b)
+            @test nrow(store.df) == 2
+
+            # Same config, different parameter → independent row too.
+            GE.record_survival_result!(store, 3.0, 50, 25, 0.50, 0.071, 1, 50, info_a)
+            @test nrow(store.df) == 3
+
+            # Persist once; reloading reproduces every continuation seed (proving the
+            # cached config strings survive a JSON round-trip).
+            GE.save_survival_results(store, csv)
+            @test isfile(csv)
+            reloaded = GE.load_survival_results(csv)
+            @test nrow(reloaded.df) == 3
+            @test GE.next_start_seed(reloaded, 1.5, info_a) == 201
+            @test GE.next_start_seed(reloaded, 1.5, info_b) == 51
+            @test GE.next_start_seed(reloaded, 3.0, info_a) == 51
+            @test GE.next_start_seed(reloaded, 2.0, info_a) == 1   # no such row
+        end
+    end
+
+    @testset "run_parameter_sweep persists and continues" begin
+        mktempdir() do dir
+            csv = joinpath(dir, "sweep.csv")
+            params = [1.5, 2.0]
+            gen = λ -> (() -> create_zim_process(10, 10, λ))
+            center = get_center_node(create_square_lattice(10, 10))
+
+            # First sweep creates the file: one row per parameter, seeds 1–5.
+            run_parameter_sweep(params, gen, [center], EscapeCriterion();
+                                save_to = csv, num_simulations = 5,
+                                use_threading = false)
+            df1 = CSV.read(csv, DataFrame)
+            @test nrow(df1) == 2
+            @test sort(df1.parameter) == params
+            @test all(df1.num_simulations .== 5)
+            @test all(df1.start_seed .== 1)
+            @test all(df1.end_seed .== 5)
+
+            # Re-running continues from seed 6 and folds in cumulative counts.
+            run_parameter_sweep(params, gen, [center], EscapeCriterion();
+                                save_to = csv, num_simulations = 5,
+                                use_threading = false)
+            df2 = CSV.read(csv, DataFrame)
+            @test nrow(df2) == 2                       # updated in place, not appended
+            @test all(df2.num_simulations .== 10)      # 5 + 5
+            @test all(df2.start_seed .== 1)            # original start preserved
+            @test all(df2.end_seed .== 10)
+        end
+    end
+
+    @testset "batched store matches single-row public functions" begin
+        mktempdir() do dir
+            # The batched store must produce a file the public get_next_start_seed
+            # reads identically (the two APIs share the same config-string logic).
+            csv = joinpath(dir, "parity.csv")
+            store = GE.load_survival_results(csv)
+            GE.record_survival_result!(store, 1.5, 100, 40, 0.40, 0.049, 1, 100, info_a)
+            GE.save_survival_results(store, csv)
+
+            @test get_next_start_seed(csv, 1.5, info_a) == 101
+            @test get_next_start_seed(csv, 1.5, info_b) == 1
+        end
+    end
+end


### PR DESCRIPTION
Four independent performance follow-ups on the simulation hot path, each in its own commit with the full suite green at every step (2393 tests, +41 new).

## 1. Allocation-free `count_neighbors_by_state` for triangular / hex / tree (`f8cb707`)
`TriangularLattice`, `HexagonalLattice`, and `RegularTree` fell back to the generic `count_neighbors_by_state`, which calls the allocating `get_neighbors` and materializes a fresh `Vector{Int}` per count — one allocation per boundary count per step on the SIR/ZIM path. Each now specializes it, mirroring its own `get_neighbors!` but testing the `Int8` state array directly (matching the lattices/structured graphs that already did).

## 2. Weighted sampler
- **2a — merge redundant samplers (`f97c377`):** `_weighted_sample_active` was just a thin forwarder to `_weighted_sample_active_fast`; every caller went through the wrapper. Folded into one function. Pure refactor.
- **2b — drop the per-step sort (`bb78122`):** the sampler rebuilt and `sort!`-ed the whole active set every Gillespie step (O(active log active)) purely for deterministic, Dict-order-independent selection. The active node ids are now kept in ascending (canonical) order **incrementally** in the tracker's add/remove/update/clear mutators, so the sampler reads that array directly. Per-step cost drops to O(active) (just the cumulative-weight pass); selection is bit-identical (ascending-node-id cumulative weights, one `rand()` per multi-node draw, single-active short-circuit unchanged), so every seeded trajectory is preserved. Keeps the tracker's **O(active)** memory model — a dense Fenwick-by-node-id was considered and rejected because it regresses memory to O(num_nodes) on the large sparse lattices this codebase targets.

## 3. O(1) SIR recovery sampling (`a07fcc2`)
`_sample_infected_uniform` walked the `infected_nodes` `Set` to the k-th element — O(#infected) per recovery step. Replaced the `Set{Int}` with a dense `Vector{Int}` plus a `node→index` `Dict`: O(1) uniform sampling, O(1) swap-removal, O(1) append. The `rand(rng, 1:n)` draw is unchanged, so seeded trajectories stay aligned.

## 4. Parameter-sweep CSV read-once / write-once (`a28d4a3`)
`run_parameter_sweep` called the single-row `get_next_start_seed` and `update_or_append_survival_result` once per parameter — each re-read (and the latter rewrote) the whole CSV and re-parsed every row's JSON, i.e. O(P) reads + O(P) full rewrites + ~O(P²) re-parses. Added a batched in-memory store in the persistence extension (`load_survival_results` / `next_start_seed` / `record_survival_result!` / `save_survival_results`): load and parse once up front, cache each row's config string, record in memory, write once at the end. The single-row public functions are kept unchanged for ad-hoc use; continuation seeds, cumulative folding, and CSV schema are preserved.

## Reviewer notes
- **Item 4 durability tradeoff:** write-once-at-end means a crash *mid-sweep* loses this run's results (previously each parameter was flushed). Cross-invocation resume still works since the file is complete once the sweep returns. Happy to switch to flushing the in-memory store after each parameter instead (no re-reads, negligible cost) if durability matters more.
- **Item 3 determinism:** like the old `Set`, the swap-remove vector's order is history-dependent, so cross-mode reproducibility is unchanged (no better, no worse) — noting it since SIR recovery selection was already not canonical the way the active tracker is.
- **Tests:** the CSV persistence path was previously untested. Added CSV/DataFrames to the test target and a `test_persistence.jl` suite (batched store load/lookup/record/save, end-to-end sweep persistence + continuation, parity with the public single-row function). Also added direct invariant tests for the incrementally-maintained `sorted_nodes` (item 2b) and the SIR infected vector/index bookkeeping (item 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)