### PR TITLE
fix: draw grid on the square-lattice image path (show_grid was ignored)

### DIFF
--- a/ext/GraphEpimodelsCairoMakieExt.jl
+++ b/ext/GraphEpimodelsCairoMakieExt.jl
@@ -120,6 +120,12 @@ function _draw_lattice!(ax, viz::LatticeVisualizer, lattice::SquareLattice,
             img[c, r] = palette[Int(states_raw[idx]) + 1]
         end
         image!(ax, (0.5, width + 0.5), (0.5, height + 0.5), img; interpolate = false)
+        # `image!` draws no cell borders, so honour `show_grid` with an explicit
+        # overlay (the transparent `poly!` path above gets grid lines for free).
+        if viz.show_grid
+            vlines!(ax, 0.5:1:(width + 0.5); color = (:gray, 0.5), linewidth = 0.5)
+            hlines!(ax, 0.5:1:(height + 0.5); color = (:gray, 0.5), linewidth = 0.5)
+        end
     end
 
     if viz.show_boundary && has_boundary(lattice)


### PR DESCRIPTION
## What
`show_grid` had no effect on square lattices rendered via the fast `image!`
path — only the transparent `poly!` path stroked cell borders. This overlays
grid lines on the `image!` path so `show_grid = true` works for square lattices
in static plots, animations, and any downstream consumer.

## Why
`image!` rasterizes a per-pixel color image and draws no cell borders, so the
`show_grid` flag was silently dropped unless `transparent_background` forced the
slower `poly!` path. Triangular/hexagonal lattices already drew the grid (they
always use `poly!`).

## Scope
6-line change in `ext/GraphEpimodelsCairoMakieExt.jl`; no API change.

## Testing
Verified with the package suite (`GRAPHEPIMODELS_VIZ_RENDER=1 Pkg.test()`) and a
before/after render confirming the grid overlay changes the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)